### PR TITLE
Update FlexibleAdapter library version to include a fix on the glitch…

### DIFF
--- a/eventdiscovery-sdk/build.gradle
+++ b/eventdiscovery-sdk/build.gradle
@@ -43,5 +43,5 @@ dependencies {
     compile 'com.github.bumptech.glide:glide:3.7.0'
     compile 'net.opacapp:multiline-collapsingtoolbar:1.3.0'
     compile 'com.google.android.gms:play-services-places:9.8.0'
-    compile 'eu.davidea:flexible-adapter:5.0.0-b8'
+    compile 'com.github.davideas:FlexibleAdapter:0320868e9319c87926e645cd620f93ab12b9ba3b'
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/eventlist/EventListActivity.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/eventlist/EventListActivity.java
@@ -115,7 +115,7 @@ public final class EventListActivity extends BaseActivity implements EvenListScr
         // Using FlexibleAdapter with sticky headers:
         FlexibleAdapter<IFlexible> adapter = new FlexibleAdapter<>(null);
         adapter.setDisplayHeadersAtStartUp(true);
-        adapter.enableStickyHeaders();
+        adapter.setStickyHeaders(true);
         AdapterNotifier adapterNotifier = new FlexibleAdapterNotifier(adapter);
 
         // Using GeneralMultiTypeAdapter (no sticky headers):

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/eventlist/itemsprovider/EventListItemsProviderImpl.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/eventlist/itemsprovider/EventListItemsProviderImpl.java
@@ -314,7 +314,7 @@ public class EventListItemsProviderImpl implements EventListItemsProvider, Event
             if (taskParam.mQuery instanceof InitialEventsDiscovery)
             {
                 mLastResultPage.put(TOP, result.mResultPage);
-//                queuePage(TOP);  // TODO re-enable when top header turning white bug is fixed
+                queuePage(TOP);
             }
         }
 


### PR DESCRIPTION
… happening when swapping sticky header for first position. Fixes #3.