### PR TITLE
PR for 16 - Force chooser upon share

### DIFF
--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/actions/ShareActionExecutable.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/actions/ShareActionExecutable.java
@@ -17,9 +17,11 @@
 
 package com.schedjoules.eventdiscovery.actions;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.support.v4.app.ShareCompat;
 import android.widget.Toast;
 
 import com.schedjoules.client.eventsdiscovery.Event;
@@ -60,10 +62,24 @@ public final class ShareActionExecutable implements ActionExecutable
 
         String eventText = eventText(context);
 
-        Intent sendIntent = new Intent();
-        sendIntent.setAction(Intent.ACTION_SEND);
-        sendIntent.putExtra(Intent.EXTRA_TEXT, eventText);
-        sendIntent.setType("text/plain");
+        Intent sendIntent;
+        if (context instanceof Activity)
+        {
+            sendIntent = ShareCompat.IntentBuilder
+                    .from((Activity) context)
+                    .setText(eventText)
+                    .setType("text/plain")
+                    .setChooserTitle(R.string.schedjoules_share_title)
+                    .createChooserIntent();
+        }
+        else
+        {
+            Intent pureIntent = new Intent();
+            pureIntent.setAction(Intent.ACTION_SEND);
+            pureIntent.putExtra(Intent.EXTRA_TEXT, eventText);
+            pureIntent.setType("text/plain");
+            sendIntent = Intent.createChooser(pureIntent, context.getString(R.string.schedjoules_share_title));
+        }
 
         if (sendIntent.resolveActivity(context.getPackageManager()) != null)
         {
@@ -76,8 +92,7 @@ public final class ShareActionExecutable implements ActionExecutable
     }
 
 
-    @NonNull
-    private String eventText(@NonNull Context context)
+    private String eventText(Context context)
     {
         URI uri = mLink.target();
         return String.format(uri == null ? "%s - %s" : "%s - %s %s",

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/actions/ShareActionExecutable.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/actions/ShareActionExecutable.java
@@ -69,7 +69,7 @@ public final class ShareActionExecutable implements ActionExecutable
                     .from((Activity) context)
                     .setText(eventText)
                     .setType("text/plain")
-                    .setChooserTitle(R.string.schedjoules_share_title)
+                    .setChooserTitle(R.string.schedjoules_action_share_chooser_title)
                     .createChooserIntent();
         }
         else
@@ -78,7 +78,7 @@ public final class ShareActionExecutable implements ActionExecutable
             pureIntent.setAction(Intent.ACTION_SEND);
             pureIntent.putExtra(Intent.EXTRA_TEXT, eventText);
             pureIntent.setType("text/plain");
-            sendIntent = Intent.createChooser(pureIntent, context.getString(R.string.schedjoules_share_title));
+            sendIntent = Intent.createChooser(pureIntent, context.getString(R.string.schedjoules_action_share_chooser_title));
         }
 
         if (sendIntent.resolveActivity(context.getPackageManager()) != null)

--- a/eventdiscovery-sdk/src/main/res/values-de/strings.xml
+++ b/eventdiscovery-sdk/src/main/res/values-de/strings.xml
@@ -29,6 +29,7 @@
     <string name="schedjoules_action_invite">Einladen</string>
     <string name="schedjoules_action_remind">Erinnern</string>
     <string name="schedjoules_action_share">Teilen</string>
+    <string name="schedjoules_action_share_chooser_title">Ereignis teilen</string>
     <string name="schedjoules_action_watch_live">Ansehen</string>
     <string name="schedjoules_default_location_placeholder_name">Alle Orte</string>
     <string name="schedjoules_entry_point">Konzerte finden</string>

--- a/eventdiscovery-sdk/src/main/res/values-nl/strings.xml
+++ b/eventdiscovery-sdk/src/main/res/values-nl/strings.xml
@@ -24,6 +24,7 @@
     <string name="schedjoules_action_book">Tickets</string>
     <string name="schedjoules_action_info">Info</string>
     <string name="schedjoules_action_share">Delen</string>
+    <string name="schedjoules_action_share_chooser_title">Delen …</string>
     <string name="schedjoules_action_call">Bellen</string>
     <string name="schedjoules_action_buy">Kopen</string>
     <string name="schedjoules_action_invite">Uitnodigen</string>

--- a/eventdiscovery-sdk/src/main/res/values/strings.xml
+++ b/eventdiscovery-sdk/src/main/res/values/strings.xml
@@ -41,5 +41,6 @@
 
     <string name="schedjoules_title_error">Error</string>
     <string name="schedjoules_generic_error">Something went wrong.\nPlease try again later.</string>
+    <string name="schedjoules_share_title">Share Event information</string>
 
 </resources>

--- a/eventdiscovery-sdk/src/main/res/values/strings.xml
+++ b/eventdiscovery-sdk/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="schedjoules_action_book">Book</string>
     <string name="schedjoules_action_info">Info</string>
     <string name="schedjoules_action_share">Share</string>
+    <string name="schedjoules_action_share_chooser_title">Share Event</string>
     <string name="schedjoules_action_call">Call</string>
     <string name="schedjoules_action_buy">Shop</string>
     <string name="schedjoules_action_invite">Invite</string>
@@ -41,6 +42,5 @@
 
     <string name="schedjoules_title_error">Error</string>
     <string name="schedjoules_generic_error">Something went wrong.\nPlease try again later.</string>
-    <string name="schedjoules_share_title">Share Event information</string>
 
 </resources>


### PR DESCRIPTION
@dmfs please review

I've added the following string as the title of the chooser, DE, NL versions could be added:
<string name="schedjoules_share_title">Share Event information</string>

There is a possibility from API level 22 to get a callback on what package the user selected in the chooser. Should we add that as Insight in a separate story?
(Descriptions:
https://developer.android.com/reference/android/content/Intent.html#createChooser(android.content.Intent, java.lang.CharSequence, android.content.IntentSender)
http://stackoverflow.com/questions/30631902/get-intentsender-object-for-createchooser-method-in-android/30693465#30693465 )
