### PR TITLE
Catch a RuntimeException thrown by httpurlconnectionexecutor in case …

### DIFF
--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/eventdetails/wizardsteps/EventLoaderStep.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/eventdetails/wizardsteps/EventLoaderStep.java
@@ -195,8 +195,9 @@ public final class EventLoaderStep implements WizardStep
                             {
                                 mActions = service.actions(mEventUid);
                             }
-                            catch (TimeoutException | InterruptedException | ProtocolError | IOException | ProtocolException | URISyntaxException e)
+                            catch (TimeoutException | InterruptedException | ProtocolError | IOException | ProtocolException | URISyntaxException | RuntimeException e)
                             {
+                                // TODO: remove RuntimeException when https://github.com/dmfs/http-client-essentials-suite/issues/36 is fixed
                                 // actions could not be loaded - fall back to an empty list
                                 mActions = Collections.emptyList();
                             }


### PR DESCRIPTION
…of a network issue. To be reverted when https://github.com/dmfs/http-client-essentials-suite/issues/36 is fixed.