### PR TITLE
upgrade MicroFragments #76

### DIFF
--- a/eventdiscovery-sdk/build.gradle
+++ b/eventdiscovery-sdk/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compile 'org.dmfs:http-client-types:0.10.2'
     compile 'org.dmfs:http-executor-decorators:0.10.2'
     compile 'org.dmfs:httpurlconnection-executor:0.10.2'
-    compile 'com.github.dmfs:MicroFragments:46d16cea953437e2229d66d656581024e4f302be'
+    compile 'com.github.dmfs:MicroFragments:b315b038a53ce44f6e7a15885b2042a5be946564'
     compile 'com.github.schedjoules:java-api-client:0.4.4'
     compile 'com.github.bumptech.glide:glide:3.7.0'
     compile 'net.opacapp:multiline-collapsingtoolbar:1.3.0'

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ActionLoaderMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ActionLoaderMicroFragment.java
@@ -44,7 +44,7 @@ import org.dmfs.android.microfragments.FragmentEnvironment;
 import org.dmfs.android.microfragments.MicroFragment;
 import org.dmfs.android.microfragments.MicroFragmentHost;
 import org.dmfs.android.microfragments.Timestamp;
-import org.dmfs.android.microfragments.UiTimestamp;
+import org.dmfs.android.microfragments.timestamps.UiTimestamp;
 import org.dmfs.android.microfragments.transitions.Faded;
 import org.dmfs.android.microfragments.transitions.ForwardTransition;
 import org.dmfs.android.microfragments.transitions.FragmentTransition;

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/EventLoaderMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/EventLoaderMicroFragment.java
@@ -43,7 +43,7 @@ import org.dmfs.android.microfragments.FragmentEnvironment;
 import org.dmfs.android.microfragments.MicroFragment;
 import org.dmfs.android.microfragments.MicroFragmentHost;
 import org.dmfs.android.microfragments.Timestamp;
-import org.dmfs.android.microfragments.UiTimestamp;
+import org.dmfs.android.microfragments.timestamps.UiTimestamp;
 import org.dmfs.android.microfragments.transitions.Faded;
 import org.dmfs.android.microfragments.transitions.ForwardTransition;
 import org.dmfs.android.microfragments.transitions.FragmentTransition;

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/feedback/FeedbackMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/feedback/FeedbackMicroFragment.java
@@ -43,7 +43,7 @@ import org.dmfs.android.microfragments.MicroFragment;
 import org.dmfs.android.microfragments.MicroFragmentEnvironment;
 import org.dmfs.android.microfragments.MicroFragmentHost;
 import org.dmfs.android.microfragments.Timestamp;
-import org.dmfs.android.microfragments.UiTimestamp;
+import org.dmfs.android.microfragments.timestamps.UiTimestamp;
 import org.dmfs.android.microfragments.transitions.BackTransition;
 import org.dmfs.android.microfragments.transitions.Faded;
 import org.dmfs.android.microfragments.transitions.ForwardTransition;

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/webview/WebviewMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/webview/WebviewMicroFragment.java
@@ -166,10 +166,10 @@ public final class WebviewMicroFragment implements MicroFragment<URI>
             mWebView.getSettings().setJavaScriptEnabled(true);
             mWebView.getSettings().setDomStorageEnabled(true);
             mWebView.setOnKeyListener(this);
-            mWebView.loadUrl(mEnvironment.microFragment().parameters().toASCIIString());
 
             if (savedInstanceState == null)
             {
+                mWebView.loadUrl(mEnvironment.microFragment().parameters().toASCIIString());
                 // TODO: make this optional
                 // wipe cookies to enforce a new login
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1)
@@ -188,6 +188,10 @@ public final class WebviewMicroFragment implements MicroFragment<URI>
                     cookieSyncMngr.sync();
                 }
             }
+            else
+            {
+                mWebView.restoreState(savedInstanceState);
+            }
 
             Toolbar toolbar = (Toolbar) root.findViewById(R.id.toolbar);
             toolbar.setTitle(mEnvironment.microFragment().title(getActivity()));
@@ -203,6 +207,33 @@ public final class WebviewMicroFragment implements MicroFragment<URI>
             });
             mProgress = (ProgressBar) root.findViewById(android.R.id.progress);
             return root;
+        }
+
+
+        @Override
+        public void onResume()
+        {
+            super.onResume();
+            mWebView.onResume();
+        }
+
+
+        @Override
+        public void onPause()
+        {
+            mWebView.onPause();
+            super.onPause();
+        }
+
+
+        @Override
+        public void onSaveInstanceState(Bundle outState)
+        {
+            if (mWebView != null)
+            {
+                mWebView.saveState(outState);
+            }
+            super.onSaveInstanceState(outState);
         }
 
 


### PR DESCRIPTION
fix imports
Note: we can't move the loaders to onCreate because the FragmentManager might call it even if the fragment is not visible at all.
try to save the webview state (not really related to the upgrade though)