### PR TITLE
update MicroFragments to fix #75

### DIFF
--- a/eventdiscovery-sdk/build.gradle
+++ b/eventdiscovery-sdk/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compile 'org.dmfs:http-client-types:0.10.2'
     compile 'org.dmfs:http-executor-decorators:0.10.2'
     compile 'org.dmfs:httpurlconnection-executor:0.10.2'
-    compile 'com.github.dmfs:MicroFragments:b315b038a53ce44f6e7a15885b2042a5be946564'
+    compile 'com.github.dmfs:MicroFragments:e12ac1615e07fb0a9012f32267696a48fda0f69b'
     compile 'com.github.schedjoules:java-api-client:0.4.4'
     compile 'com.github.bumptech.glide:glide:3.7.0'
     compile 'net.opacapp:multiline-collapsingtoolbar:1.3.0'


### PR DESCRIPTION
When Android shows a chooser, the Fragment is not stopped but just paused. When you cancel the chooser it's simply resumed. That caused a problem in the MicroFragmentHost which didn't reset the `instanceStateSaved` flag in `onResume` but only in `onStart`, hence all incoming transitions were queued instead of executed.