### PR TITLE
Release Google Places Buffer objects to avoid memory leak. #89

### DIFF
--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/tasks/PlaceByIdTask.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/tasks/PlaceByIdTask.java
@@ -50,11 +50,12 @@ public final class PlaceByIdTask extends SafeAsyncTask<NamedPlace, GoogleApiClie
     {
         GoogleApiClient googleApiClient = googleApiClients[0];
 
-        PendingResult<PlaceBuffer> placeById = Places.GeoDataApi.getPlaceById(googleApiClient, namedPlace.id());
-        PlaceBuffer placeBuffer = placeById.await();
-        Place place = placeBuffer.get(0);
+        PendingResult<PlaceBuffer> pendingResult = Places.GeoDataApi.getPlaceById(googleApiClient, namedPlace.id());
+        PlaceBuffer placeBuffer = pendingResult.await();
+        Place frozenPlace = placeBuffer.get(0).freeze();
+        placeBuffer.release();
 
-        return new StructuredGeoPlace(namedPlace, new GoogleGeoLocation(place));
+        return new StructuredGeoPlace(namedPlace, new GoogleGeoLocation(frozenPlace));
     }
 
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/tasks/PlaceSuggestionQueryTask.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/tasks/PlaceSuggestionQueryTask.java
@@ -59,14 +59,16 @@ public final class PlaceSuggestionQueryTask extends DiscardingSafeAsyncTask<Stri
     {
         GoogleApiClient googleApiClient = googleApiClients[0];
 
-        AutocompletePredictionBuffer predictions =
+        AutocompletePredictionBuffer predictionBuffer =
                 Places.GeoDataApi.getAutocompletePredictions(googleApiClient, query, null, CITIES_FILTER).await();
 
         List<ListItem> newItems = new ArrayList<>();
-        for (AutocompletePrediction prediction : predictions)
+        for (AutocompletePrediction prediction : predictionBuffer   )
         {
-            newItems.add(new PlaceSuggestionItem(new GooglePredictionNamedPlace(prediction)));
+            AutocompletePrediction frozen = prediction.freeze();
+            newItems.add(new PlaceSuggestionItem(new GooglePredictionNamedPlace(frozen)));
         }
+        predictionBuffer.release();
 
         return newItems;
     }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/tasks/PlaceSuggestionQueryTask.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/tasks/PlaceSuggestionQueryTask.java
@@ -63,7 +63,7 @@ public final class PlaceSuggestionQueryTask extends DiscardingSafeAsyncTask<Stri
                 Places.GeoDataApi.getAutocompletePredictions(googleApiClient, query, null, CITIES_FILTER).await();
 
         List<ListItem> newItems = new ArrayList<>();
-        for (AutocompletePrediction prediction : predictionBuffer   )
+        for (AutocompletePrediction prediction : predictionBuffer)
         {
             AutocompletePrediction frozen = prediction.freeze();
             newItems.add(new PlaceSuggestionItem(new GooglePredictionNamedPlace(frozen)));


### PR DESCRIPTION
Fixes #89 

Documentation about how to release the Google Buffer objects:
https://developers.google.com/places/android-api/buffers

@dmfs please review