### PR TITLE
PR for 70: Update FlexibleAdapter

### DIFF
--- a/eventdiscovery-sdk/build.gradle
+++ b/eventdiscovery-sdk/build.gradle
@@ -59,7 +59,9 @@ dependencies {
     compile 'com.github.bumptech.glide:glide:3.7.0'
     compile 'net.opacapp:multiline-collapsingtoolbar:1.3.0'
     compile 'com.google.android.gms:play-services-places:9.8.0'
-    compile 'com.github.davideas:FlexibleAdapter:0320868e9319c87926e645cd620f93ab12b9ba3b'
+    compile('eu.davidea:flexible-adapter:5.0.0-rc1') {
+        exclude group: 'com.android.support'
+    }
 
     androidTestCompile 'com.android.support:support-annotations:23.4.0'
     androidTestCompile 'com.android.support.test:runner:0.5'

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListFragment.java
@@ -59,6 +59,8 @@ import com.schedjoules.eventdiscovery.service.ApiService;
 import org.dmfs.httpessentials.types.StringToken;
 import org.dmfs.rfc5545.DateTime;
 
+import java.util.ArrayList;
+
 import eu.davidea.flexibleadapter.FlexibleAdapter;
 import eu.davidea.flexibleadapter.items.IFlexible;
 
@@ -176,7 +178,7 @@ public final class EventListFragment extends BaseFragment implements PlaceSelect
 
     private FlexibleAdapter createAdapter()
     {
-        FlexibleAdapter<IFlexible> adapter = new FlexibleAdapter<>(null);
+        FlexibleAdapter<IFlexible> adapter = new FlexibleAdapter<>(new ArrayList<IFlexible>());
         adapter.setDisplayHeadersAtStartUp(true);
         adapter.setStickyHeaders(true);
         return adapter;

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/flexibleadapter/FlexibleAdapterNotifier.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/flexibleadapter/FlexibleAdapterNotifier.java
@@ -42,16 +42,18 @@ public final class FlexibleAdapterNotifier implements ThirdPartyAdapterNotifier<
     @Override
     public void notifyInitialItemsAdded(List initialItems)
     {
-        //noinspection unchecked
-        mFlexibleAdapter.addItems(0, initialItems);
+        notifyNewItemsAdded(initialItems, 0);
     }
 
 
     @Override
     public void notifyNewItemsAdded(List newItems, int positionStart)
     {
-        //noinspection unchecked
-        mFlexibleAdapter.addItems(positionStart, newItems);
+        if (!newItems.isEmpty())
+        {
+            //noinspection unchecked
+            mFlexibleAdapter.addItems(positionStart, newItems);
+        }
     }
 
 
@@ -66,7 +68,7 @@ public final class FlexibleAdapterNotifier implements ThirdPartyAdapterNotifier<
     @Override
     public void notifyItemsCleared(int totalSize)
     {
-        mFlexibleAdapter.removeRange(0, totalSize);
+        mFlexibleAdapter.clear();
     }
 
 

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_event_list.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_event_list.xml
@@ -7,6 +7,9 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
+        <!-- Need to keep the RecyclerView within a FrameLayout
+        so that FlexibleAdapter can add the sticky header view. -->
+
         <android.support.v7.widget.RecyclerView
                 android:id="@+id/schedjoules_event_list"
                 android:layout_width="match_parent"
@@ -15,6 +18,5 @@
                 tools:context=".framework.eventlist.EventListActivity"
                 tools:listitem="@layout/schedjoules_list_item_event"/>
 
-        <include layout="@layout/sticky_header_layout"/>
     </FrameLayout>
 </layout>

--- a/eventdiscovery-sdk/src/main/res/values/list_item_ids.xml
+++ b/eventdiscovery-sdk/src/main/res/values/list_item_ids.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <item type="id" name="schedjoules_standard_event_list_item"/>
-    <item type="id" name="schedjoules_no_event_list_item"/>
-    <item type="id" name="schedjoules_date_header_list_item"/>
-</resources>


### PR DESCRIPTION
Updated FlexibleAdapter dependency to latest 5.0.0-rc1 and also excluded support libraries, so the effective support lib version of our SDK changed from 25.0.1 to 25.0.0 because of this. (I think multilinecollapsingtoolbar pulls in 25.0.0).

Also changed the usage a bit.

@dmfs please review
Please leave the story open after this has been merged.
(There will be another bigger refactor PR coming to update usage according to FlexibleAdapter wiki, namely to not add the headers to the list. I also changed multiple related classes there, it's on a local branch now, I will need the PRs merged from stories #20 and #21 before I can continue with that, in order to test the list behaviors.)