### PR TITLE
Add a BuildConfig field that determines whether to log requests or not. Implements #114

### DIFF
--- a/eventdiscovery-demo/build.gradle
+++ b/eventdiscovery-demo/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
-Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
-def googlePlacesApiKey = properties.getProperty('google.places.api.key')
+Properties localProperties = new Properties()
+localProperties.load(project.rootProject.file('local.properties').newDataInputStream())
+def googlePlacesApiKey = localProperties.getProperty('google.places.api.key')
 if (googlePlacesApiKey == null) {
     // use a dummy key instead of throwing an Exception to allow automated build on Travis, Jenkins, Jitpack et al.
     googlePlacesApiKey = "replace-me"
@@ -26,6 +26,14 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            // add BuildConfig field that tells whether to log requests or not. By default this is disabled for release builds and enabled for debug builds.
+            // to enable request logs for release builds add this line to your local.properties:
+            // request.log.enabled=true
+            buildConfigField "boolean", "LOG_REQUESTS", localProperties.getProperty("request.log.enabled", "false");
+        }
+        debug {
+            minifyEnabled false
+            buildConfigField "boolean", "LOG_REQUESTS", localProperties.getProperty("request.log.enabled", "true");
         }
     }
     dataBinding {

--- a/eventdiscovery-demo/src/main/java/com/schedjoules/eventdiscovery/demo/ApiService.java
+++ b/eventdiscovery-demo/src/main/java/com/schedjoules/eventdiscovery/demo/ApiService.java
@@ -50,7 +50,7 @@ public final class ApiService extends AbstractApiService
                                                 new DefaultRetryPolicy(3)),
                                         // make sure to use the BuildConfig of your application
                                         new VersionedProduct(BuildConfig.APPLICATION_ID, BuildConfig.VERSION_NAME)),
-                                BuildConfig.DEBUG, "EventDiscovery-Request");
+                                BuildConfig.LOG_REQUESTS, "EventDiscovery-Request");
 
                 return new SchedJoulesApi(client, executor, new SharedPrefsUserIdentifier(context));
             }


### PR DESCRIPTION
By default request logging is enabled for debug builds and disabled for release builds.
To override this behavior add the following line to your `local.properties` file:

request.log.enabled=true