### PR TITLE
PR for 95: Current city location picker module

### DIFF
--- a/.idea/dictionaries/shared_for_this_project.xml
+++ b/.idea/dictionaries/shared_for_this_project.xml
@@ -3,6 +3,7 @@
     <words>
       <w>clearable</w>
       <w>eventdiscovery</w>
+      <w>geocoder</w>
       <w>sched</w>
       <w>schedjoules</w>
       <w>sectionable</w>

--- a/eventdiscovery-demo/src/main/AndroidManifest.xml
+++ b/eventdiscovery-demo/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest package="com.schedjoules.eventdiscovery.demo"
           xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- Add this to your manifest if your targetSdkVersion < 23: -->
+    <!--suppress AndroidDomInspection -->
+    <!--<uses-permission-sdk-23 tools:node="removeAll"/>-->
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/eventdiscovery-sdk/build.gradle
+++ b/eventdiscovery-sdk/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     compile 'com.github.bumptech.glide:glide:3.7.0'
     compile 'net.opacapp:multiline-collapsingtoolbar:1.3.0'
     compile 'com.google.android.gms:play-services-places:9.8.0'
+    compile 'com.google.android.gms:play-services-location:9.8.0'
     compile('eu.davidea:flexible-adapter:5.0.0-rc1') {
         exclude group: 'com.android.support'
     }

--- a/eventdiscovery-sdk/src/main/AndroidManifest.xml
+++ b/eventdiscovery-sdk/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
           package="com.schedjoules.eventdiscovery">
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission-sdk-23 android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
     <application>
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/async/CachingSafeAsyncTask.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/async/CachingSafeAsyncTask.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.async;
+
+import android.support.annotation.WorkerThread;
+
+import com.schedjoules.eventdiscovery.framework.model.Equalable;
+import com.schedjoules.eventdiscovery.framework.utils.cache.Cache;
+
+
+/**
+ * {@link SafeAsyncTask} that uses a {@link Cache} to get results from if they are cached, otherwise executes that task and saves the result in the cache.
+ *
+ * @author Gabor Keszthelyi
+ */
+public abstract class CachingSafeAsyncTask<TASK_PARAM extends Equalable, EXECUTE_PARAM, PROGRESS, TASK_RESULT> extends SafeAsyncTask<TASK_PARAM, EXECUTE_PARAM, PROGRESS, TASK_RESULT>
+{
+    private final Cache<TASK_PARAM, TASK_RESULT> mCache;
+
+
+    public CachingSafeAsyncTask(TASK_PARAM taskParam, SafeAsyncTaskCallback<TASK_PARAM, TASK_RESULT> callback, Cache<TASK_PARAM, TASK_RESULT> cache)
+    {
+        super(taskParam, callback);
+        mCache = cache;
+    }
+
+
+    @Override
+    protected void onPreExecuteWithParam(TASK_PARAM taskParam)
+    {
+        TASK_RESULT cachedValue = mCache.get(taskParam);
+        if (cachedValue != null)
+        {
+            cancel(false);
+            onPostExecute(new SuccessTaskResult<>(cachedValue));
+        }
+    }
+
+
+    @Override
+    protected final TASK_RESULT doInBackgroundWithException(TASK_PARAM taskParam, EXECUTE_PARAM... execute_params) throws Exception
+    {
+        TASK_RESULT cachedValue = mCache.get(taskParam);
+        if (cachedValue != null)
+        {
+            return cachedValue;
+        }
+        TASK_RESULT taskResult = doInBackgroundWithExceptionForNonCached(taskParam, execute_params[0]);
+        mCache.put(taskParam, taskResult);
+        return taskResult;
+    }
+
+
+    @WorkerThread
+    protected abstract TASK_RESULT doInBackgroundWithExceptionForNonCached(TASK_PARAM taskParam, EXECUTE_PARAM execute_param) throws Exception;
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/async/SafeAsyncTask.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/async/SafeAsyncTask.java
@@ -38,7 +38,20 @@ public abstract class SafeAsyncTask<TASK_PARAM, EXECUTE_PARAM, PROGRESS, TASK_RE
     public SafeAsyncTask(TASK_PARAM taskParam, SafeAsyncTaskCallback<TASK_PARAM, TASK_RESULT> callback)
     {
         mTaskParam = taskParam;
-        mCallback = new WeakReference<SafeAsyncTaskCallback<TASK_PARAM, TASK_RESULT>>(callback);
+        mCallback = new WeakReference<>(callback);
+    }
+
+
+    @Override
+    protected final void onPreExecute()
+    {
+        onPreExecuteWithParam(mTaskParam);
+    }
+
+
+    protected void onPreExecuteWithParam(TASK_PARAM taskParam)
+    {
+
     }
 
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/http/RequestUriLogging.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/http/RequestUriLogging.java
@@ -35,7 +35,7 @@ import java.net.URI;
  *
  * @author Gabor Keszthelyi
  */
-public class RequestUriLogging implements HttpRequestExecutor
+public final class RequestUriLogging implements HttpRequestExecutor
 {
 
     private final HttpRequestExecutor mDelegate;

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/ItemChosenAction.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/ItemChosenAction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.list;
+
+/**
+ * Action that can be executed when a list item was chosen by the user.
+ *
+ * @author Gabor Keszthelyi
+ */
+public interface ItemChosenAction<T>
+{
+
+    /**
+     * Called when the item was chosen by the user.
+     *
+     * @param itemData
+     *         the data corresponding to the list item
+     */
+    void onItemChosen(T itemData);
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/changes/nonnotifying/ClearAll.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/changes/nonnotifying/ClearAll.java
@@ -27,6 +27,7 @@ import java.util.List;
  */
 public final class ClearAll<T> implements NonNotifyingListChange<T>
 {
+
     @Override
     public void apply(List<T> currentItems)
     {

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/changes/nonnotifying/ReplaceAll.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/changes/nonnotifying/ReplaceAll.java
@@ -17,6 +17,7 @@
 
 package com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying;
 
+import java.util.Collections;
 import java.util.List;
 
 
@@ -33,6 +34,12 @@ public final class ReplaceAll<T> implements NonNotifyingListChange<T>
     public ReplaceAll(List<T> newItems)
     {
         mNewItems = newItems;
+    }
+
+
+    public ReplaceAll(T item)
+    {
+        this(Collections.<T>singletonList(item));
     }
 
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/smart/AbstractSmartListItem.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/smart/AbstractSmartListItem.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.list.smart;
+
+import android.support.annotation.LayoutRes;
+import android.view.View;
+
+import com.schedjoules.eventdiscovery.framework.list.ListItem;
+import com.schedjoules.eventdiscovery.framework.utils.smartview.SmartView;
+
+
+/**
+ * Abstract class for {@link ListItem}s that work with {@link SmartView}s.
+ * <p>
+ * Note: Usually list items' 'equality' should be based on the data/model objects (type D) equality, so make sure that the data type equality is defined.
+ *
+ * @author Gabor Keszthelyi
+ */
+public abstract class AbstractSmartListItem<D, V extends View & SmartView<D>> implements ListItem<V>
+{
+    private final D mItemData;
+    private final int mLayout;
+
+
+    public AbstractSmartListItem(D itemData, @LayoutRes int layout)
+    {
+        mItemData = itemData;
+        mLayout = layout;
+    }
+
+
+    @Override
+    public final int layoutResId()
+    {
+        return mLayout;
+    }
+
+
+    @Override
+    public final void bindDataTo(V view)
+    {
+        view.update(mItemData);
+    }
+
+
+    @Override
+    public final boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        AbstractSmartListItem<?, ?> that = (AbstractSmartListItem<?, ?>) o;
+
+        return mItemData.equals(that.mItemData);
+
+    }
+
+
+    @Override
+    public final int hashCode()
+    {
+        return mItemData.hashCode();
+    }
+
+
+    @Override
+    public final String toString()
+    {
+        return toStringLabel() + "{" +
+                "itemData=" + mItemData +
+                '}';
+    }
+
+
+    /**
+     * Label that is added to the toString() value of the object, practically use the class name in string literal, like "MyListItem".
+     */
+    protected abstract String toStringLabel();
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/smart/Clickable.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/smart/Clickable.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.list.smart;
+
+import android.view.View;
+
+import com.schedjoules.eventdiscovery.framework.list.ListItem;
+import com.schedjoules.eventdiscovery.framework.utils.smartview.OnClickAction;
+
+
+/**
+ * {@link ListItem} decorator that sets up the given {@link OnClickAction} to be executed when the item View is clicked.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class Clickable<V extends View> implements ListItem<V>
+{
+
+    private final OnClickAction mOnClickAction;
+    private final ListItem<V> mDelegate;
+
+
+    public Clickable(ListItem<V> delegate, OnClickAction onClickAction)
+    {
+        mOnClickAction = onClickAction;
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public int layoutResId()
+    {
+        return mDelegate.layoutResId();
+    }
+
+
+    @Override
+    public void bindDataTo(V view)
+    {
+        mDelegate.bindDataTo(view);
+        view.setOnClickListener(new View.OnClickListener()
+        {
+            @Override
+            public void onClick(View v)
+            {
+                mOnClickAction.onClick();
+            }
+        });
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/CurrentLocationModule.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/CurrentLocationModule.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.location;
+
+import android.app.Activity;
+import android.location.Geocoder;
+import android.location.Location;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.location.LocationServices;
+import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.async.SafeAsyncTaskResult;
+import com.schedjoules.eventdiscovery.framework.list.ItemChosenAction;
+import com.schedjoules.eventdiscovery.framework.list.ListItem;
+import com.schedjoules.eventdiscovery.framework.list.smart.Clickable;
+import com.schedjoules.eventdiscovery.framework.location.listitems.MessageItem;
+import com.schedjoules.eventdiscovery.framework.location.listitems.PlaceSuggestionItem;
+import com.schedjoules.eventdiscovery.framework.location.model.AndroidGeoLocation;
+import com.schedjoules.eventdiscovery.framework.location.model.GeoPlace;
+import com.schedjoules.eventdiscovery.framework.location.model.namedplace.Equalable;
+import com.schedjoules.eventdiscovery.framework.location.tasks.GetCityTask;
+import com.schedjoules.eventdiscovery.framework.model.ParcelableGeoLocation;
+import com.schedjoules.eventdiscovery.framework.searchlist.SearchModule;
+import com.schedjoules.eventdiscovery.framework.searchlist.SearchModuleFactory;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.Clear;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.ResultUpdateListener;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.ShowSingle;
+import com.schedjoules.eventdiscovery.framework.utils.cache.Cache;
+import com.schedjoules.eventdiscovery.framework.utils.cache.TimedSingleValueCache;
+import com.schedjoules.eventdiscovery.framework.utils.factory.Caching;
+import com.schedjoules.eventdiscovery.framework.utils.factory.Factory;
+import com.schedjoules.eventdiscovery.framework.utils.smartview.OnClickAction;
+import com.schedjoules.eventdiscovery.framework.utils.strings.BasicStrings;
+import com.schedjoules.eventdiscovery.framework.utils.strings.Strings;
+
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * {@link SearchModule} for showing the current location (city, country).
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class CurrentLocationModule implements SearchModule
+{
+    public static final SearchModuleFactory<GeoPlace> FACTORY = new SearchModuleFactory<GeoPlace>()
+    {
+        @Override
+        public SearchModule create(final Activity activity, ResultUpdateListener<ListItem> updateListener, ItemChosenAction<GeoPlace> itemChosenAction)
+        {
+            GoogleApiClient googleApiClient = new GoogleApiClient
+                    .Builder(activity)
+                    .addApi(LocationServices.API)
+                    .build();
+            /**
+             * TODO enableAutomanage OR manual error handling
+             * enableAutoManage() on the builder would enable automatic default error handling as well,
+             * but it's tricky to get initialization correctly with Activity and retained Fragment lifecycles.
+             * Either enable automanage or add 'manual' error handling with addOnConnectionFailedListener().
+             *
+             * See https://developers.google.com/android/reference/com/google/android/gms/common/api/GoogleApiClient.Builder.html#enableAutoManage(android.support.v4.app.FragmentActivity, com.google.android.gms.common.api.GoogleApiClient.OnConnectionFailedListener)
+             */
+
+            googleApiClient.connect();
+
+            Factory<Geocoder> geocoderFactory = new Caching<>(new Factory<Geocoder>()
+            {
+                @Override
+                public Geocoder create()
+                {
+                    return new Geocoder(activity, Locale.getDefault());
+                }
+            });
+
+            return new CurrentLocationModule(googleApiClient, updateListener, itemChosenAction, geocoderFactory,
+                    new BasicStrings(activity));
+        }
+    };
+
+    private static final String TAG = "CurrentLocationModule";
+
+    private final GoogleApiClient mGoogleApiClient;
+    private final ResultUpdateListener<ListItem> mUpdateListener;
+    private final ItemChosenAction<GeoPlace> mItemChosenAction;
+    private final Factory<Geocoder> mGeocoderFactory;
+    private final Strings mStrings;
+
+    private final ExecutorService mExecutorService;
+
+    private final GoogleApiConnectionCallback mApiConnectionCallback;
+    private final GetCityTaskClient mGetCityTaskClient;
+
+    private final Cache<ParcelableGeoLocation, GeoPlace> mCurrentCityCache;
+
+
+    public CurrentLocationModule(GoogleApiClient googleApiClient,
+                                 ResultUpdateListener<ListItem> updateListener,
+                                 ItemChosenAction<GeoPlace> itemChosenAction,
+                                 Factory<Geocoder> geocoderFactory,
+                                 Strings strings)
+    {
+        mGoogleApiClient = googleApiClient;
+        mUpdateListener = updateListener;
+        mItemChosenAction = itemChosenAction;
+        mGeocoderFactory = geocoderFactory;
+        mStrings = strings;
+
+        mExecutorService = Executors.newSingleThreadExecutor();
+
+        mApiConnectionCallback = new GoogleApiConnectionCallback();
+        mGetCityTaskClient = new GetCityTaskClient();
+        mCurrentCityCache = new TimedSingleValueCache<>(3, TimeUnit.MINUTES);
+    }
+
+
+    @Override
+    public void shutDown()
+    {
+        mGoogleApiClient.unregisterConnectionCallbacks(mApiConnectionCallback);
+        mGoogleApiClient.disconnect();
+    }
+
+
+    @Override
+    public void onSearchQueryChange(String newQuery)
+    {
+        if (!newQuery.isEmpty())
+        {
+            mUpdateListener.onUpdate(new Clear<ListItem>(newQuery));
+        }
+        else
+        {
+            ListItem loadingItem = new MessageItem(mStrings.get(R.string.schedjoules_location_picker_current_location_locating));
+            mUpdateListener.onUpdate(new ShowSingle<>(loadingItem, ""));
+
+            // Note: If already connected, onConnected() is called immediately.
+            mGoogleApiClient.registerConnectionCallbacks(mApiConnectionCallback);
+        }
+    }
+
+
+    private void onCityReceived(final GeoPlace city)
+    {
+        ListItem item = new Clickable<>(
+                new PlaceSuggestionItem<>(new Equalable(city.namedPlace())),
+                new OnClickAction()
+                {
+                    @Override
+                    public void onClick()
+                    {
+                        mItemChosenAction.onItemChosen(city);
+                    }
+                });
+        mUpdateListener.onUpdate(new ShowSingle<>(item, ""));
+    }
+
+
+    private void onFailure()
+    {
+        ListItem errorItem = new Clickable<>(
+                new MessageItem(mStrings.get(R.string.schedjoules_location_picker_current_location_error)),
+                new OnClickAction()
+                {
+                    @Override
+                    public void onClick()
+                    {
+                        // Retry:
+                        onSearchQueryChange("");
+                    }
+                }
+        );
+        mUpdateListener.onUpdate(new ShowSingle<>(errorItem, ""));
+    }
+
+
+    private class GoogleApiConnectionCallback implements GoogleApiClient.ConnectionCallbacks
+    {
+
+        @Override
+        public void onConnected(@Nullable Bundle bundle)
+        {
+            @SuppressWarnings("MissingPermission")
+            Location lastLocation = LocationServices.FusedLocationApi.getLastLocation(mGoogleApiClient);
+
+            if (lastLocation != null)
+            {
+                ParcelableGeoLocation geoLocation = new ParcelableGeoLocation(new AndroidGeoLocation(lastLocation));
+                new GetCityTask<>(geoLocation, mGetCityTaskClient, mCurrentCityCache).executeOnExecutor(mExecutorService, mGeocoderFactory.create());
+            }
+            else
+            {
+                Log.e(TAG, "Last location is null");
+                onFailure();
+            }
+        }
+
+
+        @Override
+        public void onConnectionSuspended(int i)
+        {
+            // Based on the documentation ("GoogleApiClient will automatically attempt to restore the connection...  wait for onConnected()")
+            // we probably should do nothing here. Extra state would be needed otherwise to check
+            // whether we already have the location displayed or not.
+        }
+    }
+
+
+    private class GetCityTaskClient implements GetCityTask.Client<ParcelableGeoLocation>
+    {
+
+        @Override
+        public void onTaskFinish(SafeAsyncTaskResult<GeoPlace> result, ParcelableGeoLocation location)
+        {
+            try
+            {
+                onCityReceived(result.value());
+            }
+            catch (Exception e)
+            {
+                Log.e(TAG, "GetCityTask failed", e);
+                onFailure();
+            }
+
+        }
+
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/CurrentLocationPermissionProxyFactory.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/CurrentLocationPermissionProxyFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.location;
+
+import android.Manifest;
+
+import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.location.model.GeoPlace;
+import com.schedjoules.eventdiscovery.framework.searchlist.SearchModuleFactory;
+import com.schedjoules.eventdiscovery.framework.searchlist.permissionproxy.AbstractPermissionProxyModuleFactory;
+import com.schedjoules.eventdiscovery.framework.searchlist.permissionproxy.PermissionProxy;
+import com.schedjoules.eventdiscovery.framework.searchlist.predicate.EmptyQueryPredicate;
+
+
+/**
+ * {@link SearchModuleFactory} that decorates {@link CurrentLocationModule} with a {@link PermissionProxy} for {@link
+ * Manifest.permission#ACCESS_FINE_LOCATION}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class CurrentLocationPermissionProxyFactory extends AbstractPermissionProxyModuleFactory<GeoPlace>
+{
+
+    public CurrentLocationPermissionProxyFactory(SearchModuleFactory<GeoPlace> delegateModuleFactory)
+    {
+        super(delegateModuleFactory,
+                new EmptyQueryPredicate(),
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                R.string.schedjoules_location_picker_current_location,
+                R.string.schedjoules_location_picker_current_location_permission_rationale,
+                R.string.schedjoules_location_picker_current_location_permission_inform_about_phone_settings);
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/LocationSelectionActivity.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/LocationSelectionActivity.java
@@ -50,4 +50,5 @@ public final class LocationSelectionActivity extends BaseActivity
                     .commit();
         }
     }
+
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/listitems/MessageItem.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/listitems/MessageItem.java
@@ -15,17 +15,30 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.utils;
+package com.schedjoules.eventdiscovery.framework.location.listitems;
+
+import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.list.ListItem;
+import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
+
 
 /**
- * General factory interface.
+ * A {@link ListItem} on the location picker that displays a message.
  *
  * @author Gabor Keszthelyi
  */
-public interface Factory<T>
+public final class MessageItem extends AbstractSmartListItem<String, MessageItemView>
 {
-    /**
-     * Create the object.
-     */
-    T create();
+
+    public MessageItem(String text)
+    {
+        super(text, R.layout.schedjoules_list_item_location_message);
+    }
+
+
+    @Override
+    protected String toStringLabel()
+    {
+        return "MessageItem";
+    }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/listitems/MessageItemView.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/listitems/MessageItemView.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.location.listitems;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+
+import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.utils.smartview.SmartView;
+
+
+/**
+ * A {@link View} for a location picker list item that shows a message and can be clicked.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class MessageItemView extends RelativeLayout implements SmartView<String>
+{
+    private TextView mTextView;
+
+
+    public MessageItemView(Context context)
+    {
+        super(context);
+    }
+
+
+    public MessageItemView(Context context, AttributeSet attrs)
+    {
+        super(context, attrs);
+    }
+
+
+    @Override
+    protected void onFinishInflate()
+    {
+        super.onFinishInflate();
+        mTextView = (TextView) findViewById(R.id.schedjoules_place_message_item_title);
+    }
+
+
+    @Override
+    public void update(String text)
+    {
+        mTextView.setText(text);
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/listitems/PlaceSuggestionItem.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/listitems/PlaceSuggestionItem.java
@@ -17,96 +17,30 @@
 
 package com.schedjoules.eventdiscovery.framework.location.listitems;
 
-import android.view.View;
-
 import com.schedjoules.eventdiscovery.R;
 import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.location.model.NamedPlace;
+import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
+import com.schedjoules.eventdiscovery.framework.location.model.namedplace.NamedPlace;
+import com.schedjoules.eventdiscovery.framework.model.Equalable;
 
 
 /**
- * List item for the location suggestion.
+ * {@link ListItem} for the place suggestion items on the location picker.
  *
  * @author Gabor Keszthelyi
  */
-public final class PlaceSuggestionItem implements ListItem<PlaceSuggestionItemView>
+public final class PlaceSuggestionItem<D extends NamedPlace & Equalable> extends AbstractSmartListItem<D, PlaceSuggestionItemView<D>>
 {
-    private final NamedPlace mNamedPlace;
-
-    private OnClickListener mOnClickListener;
-
-
-    public PlaceSuggestionItem(NamedPlace namedPlace)
+    public PlaceSuggestionItem(D namedPlace)
     {
-        mNamedPlace = namedPlace;
+        super(namedPlace, R.layout.schedjoules_list_item_place_suggestion);
     }
 
 
     @Override
-    public int layoutResId()
+    protected String toStringLabel()
     {
-        return R.layout.schedjoules_list_item_place_suggestion;
+        return "PlaceSuggestionItem";
     }
 
-
-    @Override
-    public void bindDataTo(PlaceSuggestionItemView view)
-    {
-        view.update(mNamedPlace);
-        view.setOnClickListener(new View.OnClickListener()
-        {
-            @Override
-            public void onClick(View v)
-            {
-                mOnClickListener.onPlaceSuggestionSelected(mNamedPlace);
-            }
-        });
-    }
-
-
-    @Override
-    public boolean equals(Object o)
-    {
-        if (this == o)
-        {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass())
-        {
-            return false;
-        }
-
-        PlaceSuggestionItem that = (PlaceSuggestionItem) o;
-
-        return mNamedPlace.id().equals(that.mNamedPlace.id());
-
-    }
-
-
-    @Override
-    public int hashCode()
-    {
-        return mNamedPlace.id().hashCode();
-    }
-
-
-    public void setListener(OnClickListener listener)
-    {
-        mOnClickListener = listener;
-    }
-
-
-    @Override
-    public String toString()
-    {
-        return "PlaceSuggestionItem{" +
-                "mNamedPlace=" + mNamedPlace.name() +
-                '}';
-    }
-
-
-    public interface OnClickListener
-    {
-        void onPlaceSuggestionSelected(NamedPlace namedPlace);
-    }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/listitems/PlaceSuggestionItemView.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/listitems/PlaceSuggestionItemView.java
@@ -19,12 +19,12 @@ package com.schedjoules.eventdiscovery.framework.location.listitems;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.location.model.NamedPlace;
-import com.schedjoules.eventdiscovery.framework.utils.SmartView;
+import com.schedjoules.eventdiscovery.framework.location.model.namedplace.NamedPlace;
+import com.schedjoules.eventdiscovery.framework.utils.smartview.SmartView;
 
 
 /**
@@ -32,7 +32,7 @@ import com.schedjoules.eventdiscovery.framework.utils.SmartView;
  *
  * @author Gabor Keszthelyi
  */
-public final class PlaceSuggestionItemView extends LinearLayout implements SmartView<NamedPlace>
+public final class PlaceSuggestionItemView<T extends NamedPlace> extends RelativeLayout implements SmartView<T>
 {
 
     private TextView mName;
@@ -55,7 +55,7 @@ public final class PlaceSuggestionItemView extends LinearLayout implements Smart
 
 
     @Override
-    public void update(NamedPlace namedPlace)
+    public void update(T namedPlace)
     {
         mName.setText(namedPlace.name());
         mExtraContext.setText(namedPlace.extraContext());

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/AndroidGeoLocation.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/AndroidGeoLocation.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.location.model;
+
+import android.location.Location;
+
+import com.schedjoules.client.eventsdiscovery.GeoLocation;
+import com.schedjoules.client.eventsdiscovery.locations.StructuredGeoLocation;
+
+
+/**
+ * {@link GeoLocation} adapting Android's {@link Location}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class AndroidGeoLocation implements GeoLocation
+{
+    private final Location mLocation;
+
+
+    public AndroidGeoLocation(Location location)
+    {
+        mLocation = location;
+    }
+
+
+    @Override
+    public float latitude()
+    {
+        return (float) mLocation.getLatitude();
+    }
+
+
+    @Override
+    public float longitude()
+    {
+        return (float) mLocation.getLongitude();
+    }
+
+
+    @Override
+    public String toString()
+    {
+        return new StructuredGeoLocation(latitude(), longitude()).toString();
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/Anywhere.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/Anywhere.java
@@ -21,6 +21,7 @@ import android.content.Context;
 
 import com.schedjoules.client.eventsdiscovery.GeoLocation;
 import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.location.model.namedplace.NamedPlace;
 import com.schedjoules.eventdiscovery.framework.model.UndefinedGeoLocation;
 
 
@@ -69,8 +70,7 @@ public final class Anywhere implements GeoPlace
         @Override
         public String id()
         {
-            throw new UnsupportedOperationException(
-                    String.format("%s doesn't have id, just name", Anywhere.class.getName()));
+            return "Anywhere";
         }
 
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/GeoPlace.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/GeoPlace.java
@@ -18,6 +18,7 @@
 package com.schedjoules.eventdiscovery.framework.location.model;
 
 import com.schedjoules.client.eventsdiscovery.GeoLocation;
+import com.schedjoules.eventdiscovery.framework.location.model.namedplace.NamedPlace;
 
 
 /**

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/GooglePredictionNamedPlace.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/GooglePredictionNamedPlace.java
@@ -18,6 +18,7 @@
 package com.schedjoules.eventdiscovery.framework.location.model;
 
 import com.google.android.gms.location.places.AutocompletePrediction;
+import com.schedjoules.eventdiscovery.framework.location.model.namedplace.NamedPlace;
 
 
 /**

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/ParcelableGeoPlace.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/ParcelableGeoPlace.java
@@ -21,6 +21,7 @@ import android.os.Parcel;
 import android.os.Parcelable;
 
 import com.schedjoules.client.eventsdiscovery.GeoLocation;
+import com.schedjoules.eventdiscovery.framework.location.model.namedplace.NamedPlace;
 import com.schedjoules.eventdiscovery.framework.model.ParcelableGeoLocation;
 
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/StructuredGeoPlace.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/StructuredGeoPlace.java
@@ -18,6 +18,7 @@
 package com.schedjoules.eventdiscovery.framework.location.model;
 
 import com.schedjoules.client.eventsdiscovery.GeoLocation;
+import com.schedjoules.eventdiscovery.framework.location.model.namedplace.NamedPlace;
 
 
 /**

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/StructuredNamedPlace.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/StructuredNamedPlace.java
@@ -17,6 +17,9 @@
 
 package com.schedjoules.eventdiscovery.framework.location.model;
 
+import com.schedjoules.eventdiscovery.framework.location.model.namedplace.NamedPlace;
+
+
 /**
  * @author Gabor Keszthelyi
  */

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/namedplace/Equalable.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/namedplace/Equalable.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.location.model.namedplace;
+
+/**
+ * {@link com.schedjoules.eventdiscovery.framework.model.Equalable} decorator for {@link NamedPlace}, value is based on id().
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class Equalable implements NamedPlace, com.schedjoules.eventdiscovery.framework.model.Equalable
+{
+    private final NamedPlace mNamedPlace;
+
+
+    public Equalable(NamedPlace namedPlace)
+    {
+        mNamedPlace = namedPlace;
+    }
+
+
+    @Override
+    public String id()
+    {
+        return mNamedPlace.id();
+    }
+
+
+    @Override
+    public CharSequence name()
+    {
+        return mNamedPlace.name();
+    }
+
+
+    @Override
+    public CharSequence extraContext()
+    {
+        return mNamedPlace.extraContext();
+    }
+
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        Equalable equalable = (Equalable) o;
+
+        return id().equals(equalable.id());
+
+    }
+
+
+    @Override
+    public int hashCode()
+    {
+        return id().hashCode();
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/namedplace/NamedPlace.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/namedplace/NamedPlace.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.location.model.namedplace;
+
+/**
+ * Represents a place (city, venue, place) with a name and identifier.
+ *
+ * @author Gabor Keszthelyi
+ */
+public interface NamedPlace
+{
+
+    /**
+     * The unique id for this place.
+     */
+    String id();
+
+    /**
+     * The main name of the place. For a city, it's the city name. For other place it's the name of the place.
+     */
+    CharSequence name();
+
+    /**
+     * The extra context for the place. For a city, it's the country. For other place it's mostly the address, including the city.
+     */
+    CharSequence extraContext();
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/tasks/GetCityTask.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/tasks/GetCityTask.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.location.tasks;
+
+import android.location.Address;
+import android.location.Geocoder;
+import android.os.AsyncTask;
+
+import com.schedjoules.client.eventsdiscovery.GeoLocation;
+import com.schedjoules.eventdiscovery.framework.async.CachingSafeAsyncTask;
+import com.schedjoules.eventdiscovery.framework.async.SafeAsyncTaskCallback;
+import com.schedjoules.eventdiscovery.framework.location.model.GeoPlace;
+import com.schedjoules.eventdiscovery.framework.location.model.StructuredGeoPlace;
+import com.schedjoules.eventdiscovery.framework.location.model.StructuredNamedPlace;
+import com.schedjoules.eventdiscovery.framework.location.model.namedplace.NamedPlace;
+import com.schedjoules.eventdiscovery.framework.model.Equalable;
+import com.schedjoules.eventdiscovery.framework.utils.cache.Cache;
+
+import java.util.List;
+
+
+/**
+ * {@link AsyncTask} to get the current city and country name using {@link Geocoder} given a geo location.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class GetCityTask<GL extends GeoLocation & Equalable> extends CachingSafeAsyncTask<GL, Geocoder, Void, GeoPlace>
+{
+
+    public GetCityTask(GL location, Client<GL> client, Cache<GL, GeoPlace> cache)
+    {
+        super(location, client, cache);
+    }
+
+
+    @Override
+    protected GeoPlace doInBackgroundWithExceptionForNonCached(GL location, Geocoder geocoder) throws Exception
+    {
+        List<Address> addresses = geocoder.getFromLocation((double) location.latitude(), (double) location.longitude(), 1);
+
+        if (addresses == null || addresses.isEmpty())
+        {
+            throw new RuntimeException("No address returned by Geocoder.");
+        }
+
+        Address address = addresses.get(0);
+        String id = String.format("LocatedCity-%s-%s-%s",
+                address.getCountryCode(), address.getLocality(), location.toString());
+        NamedPlace namedPlace = new StructuredNamedPlace(id, address.getLocality(), address.getCountryName());
+        return new StructuredGeoPlace(namedPlace, location);
+    }
+
+
+    public interface Client<GL extends GeoLocation & Equalable> extends SafeAsyncTaskCallback<GL, GeoPlace>
+    {
+
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/tasks/PlaceByIdTask.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/tasks/PlaceByIdTask.java
@@ -28,8 +28,8 @@ import com.schedjoules.eventdiscovery.framework.async.SafeAsyncTask;
 import com.schedjoules.eventdiscovery.framework.async.SafeAsyncTaskCallback;
 import com.schedjoules.eventdiscovery.framework.location.model.GeoPlace;
 import com.schedjoules.eventdiscovery.framework.location.model.GoogleGeoLocation;
-import com.schedjoules.eventdiscovery.framework.location.model.NamedPlace;
 import com.schedjoules.eventdiscovery.framework.location.model.StructuredGeoPlace;
+import com.schedjoules.eventdiscovery.framework.location.model.namedplace.NamedPlace;
 
 
 /**

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/tasks/PlaceSuggestionQueryTask.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/tasks/PlaceSuggestionQueryTask.java
@@ -26,9 +26,8 @@ import com.google.android.gms.location.places.AutocompletePredictionBuffer;
 import com.google.android.gms.location.places.Places;
 import com.schedjoules.eventdiscovery.framework.async.SafeAsyncTask;
 import com.schedjoules.eventdiscovery.framework.async.SafeAsyncTaskCallback;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.location.listitems.PlaceSuggestionItem;
 import com.schedjoules.eventdiscovery.framework.location.model.GooglePredictionNamedPlace;
+import com.schedjoules.eventdiscovery.framework.location.model.namedplace.NamedPlace;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +38,7 @@ import java.util.List;
  *
  * @author Gabor Keszthelyi
  */
-public final class PlaceSuggestionQueryTask extends SafeAsyncTask<String, GoogleApiClient, Void, List<ListItem>>
+public final class PlaceSuggestionQueryTask extends SafeAsyncTask<String, GoogleApiClient, Void, List<NamedPlace>>
 {
 
     private static final AutocompleteFilter CITIES_FILTER = new AutocompleteFilter.Builder()
@@ -54,26 +53,26 @@ public final class PlaceSuggestionQueryTask extends SafeAsyncTask<String, Google
 
 
     @Override
-    protected List<ListItem> doInBackgroundWithException(String query, GoogleApiClient... googleApiClients) throws Exception
+    protected List<NamedPlace> doInBackgroundWithException(String query, GoogleApiClient... googleApiClients) throws Exception
     {
         GoogleApiClient googleApiClient = googleApiClients[0];
 
         AutocompletePredictionBuffer predictionBuffer =
                 Places.GeoDataApi.getAutocompletePredictions(googleApiClient, query, null, CITIES_FILTER).await();
 
-        List<ListItem> newItems = new ArrayList<>();
+        List<NamedPlace> places = new ArrayList<>();
         for (AutocompletePrediction prediction : predictionBuffer)
         {
             AutocompletePrediction frozen = prediction.freeze();
-            newItems.add(new PlaceSuggestionItem(new GooglePredictionNamedPlace(frozen)));
+            places.add(new GooglePredictionNamedPlace(frozen));
         }
         predictionBuffer.release();
 
-        return newItems;
+        return places;
     }
 
 
-    public interface Client extends SafeAsyncTaskCallback<String, List<ListItem>>
+    public interface Client extends SafeAsyncTaskCallback<String, List<NamedPlace>>
     {
 
     }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/model/Equalable.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/model/Equalable.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.model;
+
+/**
+ * Interface for marking types whose implementation has to override equals() and hashCode().
+ *
+ * @author Gabor Keszthelyi
+ */
+public interface Equalable
+{
+    /**
+     * See {@link Object#equals(Object)}
+     */
+    boolean equals(Object other);
+
+    /**
+     * See {@link Object#hashCode()}
+     */
+    int hashCode();
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/model/ParcelableGeoLocation.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/model/ParcelableGeoLocation.java
@@ -29,7 +29,7 @@ import com.schedjoules.client.eventsdiscovery.locations.StructuredGeoLocation;
  *
  * @author Marten Gajda
  */
-public final class ParcelableGeoLocation implements GeoLocation, Parcelable
+public final class ParcelableGeoLocation implements GeoLocation, Parcelable, Equalable
 {
     public static final Creator<ParcelableGeoLocation> CREATOR = new Creator<ParcelableGeoLocation>()
     {

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/AppPermissions.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/AppPermissions.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.permissions;
+
+/**
+ * Set of Android's app permissions.
+ *
+ * @author Marten Gajda
+ */
+public interface AppPermissions
+{
+
+    /**
+     * Return the {@link Permission} of the given name.
+     *
+     * @param permissionName
+     *         The name of the {@link Permission} to return.
+     *
+     * @return A {@link Permission}.
+     */
+    Permission forName(String permissionName);
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/BasicAppPermissions.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/BasicAppPermissions.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.permissions;
+
+import android.content.Context;
+import android.os.Build;
+
+
+/**
+ * Basic {@link AppPermissions} implementation. It automatically handles different permission support on different Android versions.
+ *
+ * @author Marten Gajda
+ */
+public final class BasicAppPermissions implements AppPermissions
+{
+    private final AppPermissions mDelegate;
+
+
+    public BasicAppPermissions(Context context)
+    {
+        mDelegate = Build.VERSION.SDK_INT < 23 ? new LegacyAppPermissions(context) : new MarshmallowPermissions(context);
+    }
+
+
+    @Override
+    public Permission forName(String permissionName)
+    {
+        return mDelegate.forName(permissionName);
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/LegacyAppPermissions.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/LegacyAppPermissions.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.permissions;
+
+import android.app.Activity;
+import android.content.Context;
+import android.support.v4.content.ContextCompat;
+
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+
+
+/**
+ * {@link AppPermissions} on Android API level <23.
+ * <p>
+ * This is not intended for public use. Use {@link BasicAppPermissions} instead.
+ *
+ * @author Marten Gajda
+ */
+final class LegacyAppPermissions implements AppPermissions
+{
+    private final Context mAppContext;
+
+
+    LegacyAppPermissions(Context appContext)
+    {
+        mAppContext = appContext.getApplicationContext();
+    }
+
+
+    @Override
+    public Permission forName(String permissionName)
+    {
+        return new LegacyPermission(permissionName, ContextCompat.checkSelfPermission(mAppContext, permissionName) == PERMISSION_GRANTED);
+    }
+
+
+    /**
+     * A {@link Permission} on API levels < 23.
+     */
+    private static final class LegacyPermission implements Permission
+    {
+        private final String mName;
+        private final boolean mIsGranted;
+
+
+        LegacyPermission(String name, boolean isGranted)
+        {
+            mName = name;
+            mIsGranted = isGranted;
+        }
+
+
+        @Override
+        public String name()
+        {
+            return mName;
+        }
+
+
+        @Override
+        public boolean isGranted()
+        {
+            return mIsGranted;
+        }
+
+
+        @Override
+        public boolean isRequestable(Activity activity)
+        {
+            return isGranted();
+        }
+
+
+        @Override
+        public boolean isGrantable()
+        {
+            return false;
+        }
+
+
+        @Override
+        public PermissionRequest request()
+        {
+            return new NoOpPermissionRequest();
+        }
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/MarshmallowPermissions.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/MarshmallowPermissions.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.permissions;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+
+import com.schedjoules.eventdiscovery.framework.permissions.utils.ManifestPermissionStrings;
+
+import org.dmfs.iterators.FilteredIterator;
+import org.dmfs.iterators.filters.AnyOf;
+
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+
+
+/**
+ * {@link AppPermissions} on Android 6 and newer.
+ * <p>
+ * This is not intended for public use. Use {@link BasicAppPermissions} instead.
+ *
+ * @author Marten Gajda
+ */
+final class MarshmallowPermissions implements AppPermissions
+{
+    private final Context mContext;
+    private final SharedPreferences mSharedPreferences;
+
+
+    MarshmallowPermissions(Context context)
+    {
+        mContext = context.getApplicationContext();
+        mSharedPreferences = mContext.getSharedPreferences("com.schedjoules.permissions", 0);
+    }
+
+
+    @Override
+    public Permission forName(final String permissionName)
+    {
+        return new MarshmallowPermission(mContext, mSharedPreferences, permissionName);
+    }
+
+
+    /**
+     * A {@link Permission} on API levels >= 23.
+     * <p>
+     * In contrast to {@link LegacyAppPermissions.LegacyPermission} this determines the state on access and may be grantable at runtime.
+     */
+    private static final class MarshmallowPermission implements Permission
+    {
+        private final Context mContext;
+        private final SharedPreferences mSharedPreferences;
+        private final String mName;
+
+
+        MarshmallowPermission(Context context, SharedPreferences sharedPreferences, String name)
+        {
+            mContext = context.getApplicationContext();
+            mSharedPreferences = sharedPreferences;
+            mName = name;
+        }
+
+
+        @Override
+        public String name()
+        {
+            return mName;
+        }
+
+
+        @Override
+        public boolean isGranted()
+        {
+            return ContextCompat.checkSelfPermission(mContext, mName) == PERMISSION_GRANTED;
+        }
+
+
+        @Override
+        public boolean isRequestable(Activity activity)
+        {
+            return isGranted() ||
+                    isGrantable() && (!mSharedPreferences.contains(mName) || ActivityCompat.shouldShowRequestPermissionRationale(activity, mName));
+        }
+
+
+        @Override
+        public boolean isGrantable()
+        {
+            return new FilteredIterator<>(new ManifestPermissionStrings(mContext).iterator(), new AnyOf<>(mName)).hasNext();
+        }
+
+
+        @Override
+        public PermissionRequest request()
+        {
+            return new MarshmallowPermissionRequest(mName, mSharedPreferences);
+        }
+
+    }
+
+
+    /**
+     * A simple {@link PermissionRequest}.
+     */
+    private final static class MarshmallowPermissionRequest implements PermissionRequest
+    {
+        private final String mName;
+        private final SharedPreferences mSharedPreferences;
+
+
+        private MarshmallowPermissionRequest(String mName, SharedPreferences mSharedPreferences)
+        {
+            this.mName = mName;
+            this.mSharedPreferences = mSharedPreferences;
+        }
+
+
+        @Override
+        public PermissionRequest withPermission(Permission... permissions)
+        {
+            throw new UnsupportedOperationException("Not implemented yet.");
+        }
+
+
+        @Override
+        public void send(Activity activity)
+        {
+            // store the fact that we just requested the permission
+            mSharedPreferences.edit().putBoolean(mName, true).apply();
+            ActivityCompat.requestPermissions(activity, new String[] { mName }, 1);
+        }
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/NoOpPermissionRequest.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/NoOpPermissionRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.permissions;
+
+import android.app.Activity;
+
+
+/**
+ * A {@link PermissionRequest} that doesn't do anything. It's meant as a dummy request on Android <6.
+ *
+ * @author Marten Gajda
+ */
+public final class NoOpPermissionRequest implements PermissionRequest
+{
+    @Override
+    public PermissionRequest withPermission(Permission... permissions)
+    {
+        return this;
+    }
+
+
+    @Override
+    public void send(Activity activity)
+    {
+        // do nothing
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/Permission.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/Permission.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.permissions;
+
+import android.app.Activity;
+
+
+/**
+ * Represents a single Android permission.
+ *
+ * @author Marten Gajda
+ */
+public interface Permission
+{
+    /**
+     * The name of this permission.
+     *
+     * @return A String containing the permission name.
+     */
+    String name();
+
+    /**
+     * Return whether this permission is granted or not.
+     *
+     * @return {@code true} if this permission has been granted to the app, {@code false} otherwise.
+     */
+    boolean isGranted();
+
+    /**
+     * Returns whether this permission can be requested at runtime. If this returns true you may use {@link #request()} to create a {@link PermissionRequest}
+     * and send it.
+     * <p>
+     * Note that this also returns {@code true} if the permission has already been granted.
+     *
+     * @param activity
+     *         The current {@link Activity}.
+     *
+     * @return {@code true} if this permission can be requested at runtime, {@code false} otherwise.
+     */
+    boolean isRequestable(Activity activity);
+
+    /**
+     * Returns whether this permission can be granted at runtime, either by a runtime permission request or in the settings of the device.
+     * <p>
+     * If this returns {@code true} but {@link #isRequestable(Activity)} returns {@code false} the user needs to go to the system settings in order to grant a
+     * permission.
+     *
+     * @return {@code true} if and only if the permission can be granted at runtime.
+     */
+    boolean isGrantable();
+
+    /**
+     * Creates a {@link PermissionRequest} to request this {@link Permission}.
+     *
+     * @return A new {@link PermissionRequest} for this single {@link Permission}.
+     */
+    PermissionRequest request();
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/PermissionRequest.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/PermissionRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.permissions;
+
+import android.app.Activity;
+
+
+/**
+ * A request to grant a permission.
+ *
+ * @author Marten Gajda
+ */
+public interface PermissionRequest
+{
+    /**
+     * Adds the given {@link Permission}s to this request.
+     *
+     * @param permissions
+     *         An array of {@link Permission}s.
+     *
+     * @return A new {@link PermissionRequest} that also asks for the added {@link Permission}s.
+     */
+    PermissionRequest withPermission(Permission... permissions);
+
+    /**
+     * Send this {@link PermissionRequest} and ask the user to grant the {@link Permission}s.
+     *
+     * @param activity
+     *         An {@link Activity}.
+     */
+    void send(Activity activity);
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/utils/ManifestPermissionStrings.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/permissions/utils/ManifestPermissionStrings.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.permissions.utils;
+
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+
+import org.dmfs.iterators.ArrayIterator;
+
+import java.util.Iterator;
+
+
+/**
+ * An {@link Iterable} iterating all permission strings in the Manifest of this app.
+ *
+ * @author Marten Gajda
+ */
+public final class ManifestPermissionStrings implements Iterable<String>
+{
+    private final Context mAppContext;
+
+
+    public ManifestPermissionStrings(Context context)
+    {
+        mAppContext = context.getApplicationContext();
+    }
+
+
+    @Override
+    public Iterator<String> iterator()
+    {
+        try
+        {
+            PackageInfo packageInfo = mAppContext.getPackageManager().getPackageInfo(mAppContext.getPackageName(), PackageManager.GET_PERMISSIONS);
+            return new ArrayIterator<>(packageInfo.requestedPermissions);
+        }
+        catch (PackageManager.NameNotFoundException e)
+        {
+            throw new RuntimeException("WTF! Own package not found by PackageManager?!", e);
+        }
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/BasicSearchListItems.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/BasicSearchListItems.java
@@ -23,6 +23,7 @@ import com.schedjoules.eventdiscovery.framework.list.ListItem;
 import com.schedjoules.eventdiscovery.framework.list.changes.notifying.ListChange;
 import com.schedjoules.eventdiscovery.framework.list.sectioned.SectionableListItem;
 import com.schedjoules.eventdiscovery.framework.list.sectioned.SectionedChangeableListProxy;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.ResultUpdate;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/NoOpSearchModule.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/NoOpSearchModule.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.searchlist;
+
+/**
+ * No operation {@link SearchModule}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class NoOpSearchModule implements SearchModule
+{
+    @Override
+    public void shutDown()
+    {
+
+    }
+
+
+    @Override
+    public void onSearchQueryChange(String newQuery)
+    {
+
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/SearchListItems.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/SearchListItems.java
@@ -21,6 +21,7 @@ import com.schedjoules.eventdiscovery.framework.list.ListItem;
 import com.schedjoules.eventdiscovery.framework.list.ListItems;
 import com.schedjoules.eventdiscovery.framework.list.changes.notifying.ChangeableListItems;
 import com.schedjoules.eventdiscovery.framework.list.sectioned.SectionableListItem;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.SectionedResultUpdateListener;
 
 
 /**

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/SearchModuleFactory.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/SearchModuleFactory.java
@@ -19,17 +19,18 @@ package com.schedjoules.eventdiscovery.framework.searchlist;
 
 import android.app.Activity;
 
+import com.schedjoules.eventdiscovery.framework.list.ItemChosenAction;
 import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.ListItemSelectionAction;
 import com.schedjoules.eventdiscovery.framework.location.PlaceSuggestionModule;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.ResultUpdateListener;
 
 
 /**
  * Factory for creating {@link SearchModule} for a search list.
  * <p>
- * Note: The reason why the {@link ListItemSelectionAction} is passed in to the {@link SearchModule} to be executed by it, instead of handling it generally
- * outside of the {@link SearchModule}, is that it may need to make extra calls when the user clicks, to fetch the actual data represented by the item. (Example
- * is {@link PlaceSuggestionModule})
+ * Note: The reason why the {@link ItemChosenAction} is passed in to the {@link SearchModule} to be executed by it, instead of handling it generally outside of
+ * the {@link SearchModule}, is that it may need to make extra calls when the user clicks, to fetch the actual data represented by the item. (Example is {@link
+ * PlaceSuggestionModule})
  *
  * @author Gabor Keszthelyi
  */
@@ -42,10 +43,10 @@ public interface SearchModuleFactory<ITEM_DATA>
      *         can be used to initiate connections/resources that the {@link SearchModule} may need
      * @param updateListener
      *         the {@link SearchModule} can use this to send update requests about its section in the list.
-     * @param itemSelectionAction
-     *         should be executed by the {@link SearchModule} when the user selects an item
+     * @param itemChosenAction
+     *         should be executed by the {@link SearchModule} when the user has chosen an item
      *
      * @return new instance of {@link SearchModule}
      */
-    SearchModule create(Activity activity, ResultUpdateListener<ListItem> updateListener, ListItemSelectionAction<ITEM_DATA> itemSelectionAction);
+    SearchModule create(Activity activity, ResultUpdateListener<ListItem> updateListener, ItemChosenAction<ITEM_DATA> itemChosenAction);
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/SearchModulesFactory.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/SearchModulesFactory.java
@@ -19,8 +19,9 @@ package com.schedjoules.eventdiscovery.framework.searchlist;
 
 import android.app.Activity;
 
-import com.schedjoules.eventdiscovery.framework.list.ListItemSelectionAction;
-import com.schedjoules.eventdiscovery.framework.utils.Factory;
+import com.schedjoules.eventdiscovery.framework.list.ItemChosenAction;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.SectionedResultUpdateListenerAdapter;
+import com.schedjoules.eventdiscovery.framework.utils.factory.Factory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,18 +36,18 @@ public final class SearchModulesFactory<ITEM_DATA> implements Factory<List<Searc
 {
     private final Activity mActivity;
     private final SearchListItems mSearchListItems;
-    private final ListItemSelectionAction<ITEM_DATA> mItemSelectionAction;
+    private final ItemChosenAction<ITEM_DATA> mItemChosenAction;
     private final List<SearchModuleFactory<ITEM_DATA>> mFactories;
 
 
     public SearchModulesFactory(Activity activity,
                                 SearchListItems searchListItems,
-                                ListItemSelectionAction<ITEM_DATA> itemSelectionAction,
+                                ItemChosenAction<ITEM_DATA> itemChosenAction,
                                 List<SearchModuleFactory<ITEM_DATA>> factories)
     {
         mActivity = activity;
         mSearchListItems = searchListItems;
-        mItemSelectionAction = itemSelectionAction;
+        mItemChosenAction = itemChosenAction;
         mFactories = factories;
     }
 
@@ -62,7 +63,7 @@ public final class SearchModulesFactory<ITEM_DATA> implements Factory<List<Searc
                     mActivity,
                     // Adding 1000 to the index to avoid confusion with list positions
                     new SectionedResultUpdateListenerAdapter<>(i + 1000, mSearchListItems),
-                    mItemSelectionAction);
+                    mItemChosenAction);
             modules.add(searchModule);
         }
         return modules;

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/delaying/DelayingUpdateListener.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/delaying/DelayingUpdateListener.java
@@ -21,8 +21,8 @@ import android.os.Handler;
 import android.os.Looper;
 
 import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.searchlist.ResultUpdate;
-import com.schedjoules.eventdiscovery.framework.searchlist.SectionedResultUpdateListener;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.ResultUpdate;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.SectionedResultUpdateListener;
 
 import java.util.Iterator;
 import java.util.LinkedList;

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/delaying/UpdateDelaying.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/delaying/UpdateDelaying.java
@@ -23,9 +23,9 @@ import android.support.v7.widget.RecyclerView;
 import com.schedjoules.eventdiscovery.framework.list.ListItem;
 import com.schedjoules.eventdiscovery.framework.list.changes.notifying.ListChange;
 import com.schedjoules.eventdiscovery.framework.list.sectioned.SectionableListItem;
-import com.schedjoules.eventdiscovery.framework.searchlist.ResultUpdate;
 import com.schedjoules.eventdiscovery.framework.searchlist.SearchListItems;
-import com.schedjoules.eventdiscovery.framework.searchlist.SectionedResultUpdateListener;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.ResultUpdate;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.SectionedResultUpdateListener;
 
 
 /**

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/permissionproxy/AbstractPermissionProxyModuleFactory.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/permissionproxy/AbstractPermissionProxyModuleFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.searchlist.permissionproxy;
+
+import android.app.Activity;
+import android.support.annotation.StringRes;
+
+import com.schedjoules.eventdiscovery.framework.list.ItemChosenAction;
+import com.schedjoules.eventdiscovery.framework.list.ListItem;
+import com.schedjoules.eventdiscovery.framework.permissions.AppPermissions;
+import com.schedjoules.eventdiscovery.framework.permissions.BasicAppPermissions;
+import com.schedjoules.eventdiscovery.framework.permissions.Permission;
+import com.schedjoules.eventdiscovery.framework.searchlist.NoOpSearchModule;
+import com.schedjoules.eventdiscovery.framework.searchlist.SearchModule;
+import com.schedjoules.eventdiscovery.framework.searchlist.SearchModuleFactory;
+import com.schedjoules.eventdiscovery.framework.searchlist.predicate.QueryPredicate;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.ResultUpdateListener;
+
+
+/**
+ * {@link SearchModuleFactory} for {@link PermissionProxy}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public abstract class AbstractPermissionProxyModuleFactory<ITEM_DATA> implements SearchModuleFactory<ITEM_DATA>
+{
+    private final SearchModuleFactory<ITEM_DATA> mDelegateModuleFactory;
+    private final QueryPredicate mQueryPredicate;
+    private final String mPermissionName;
+    private final int mNotAskedYetMessage;
+    private final int mDeniedMessage;
+    private final int mDeniedWithNeverAskAgainMessage;
+
+
+    public AbstractPermissionProxyModuleFactory(SearchModuleFactory<ITEM_DATA> delegateModuleFactory,
+                                                QueryPredicate queryPredicate,
+                                                String permissionName,
+                                                @StringRes int notAskedYetMessage,
+                                                @StringRes int deniedMessage,
+                                                @StringRes int deniedWithNeverAskAgainMessage)
+    {
+        mDelegateModuleFactory = delegateModuleFactory;
+        mQueryPredicate = queryPredicate;
+        mPermissionName = permissionName;
+        mNotAskedYetMessage = notAskedYetMessage;
+        mDeniedMessage = deniedMessage;
+        mDeniedWithNeverAskAgainMessage = deniedWithNeverAskAgainMessage;
+    }
+
+
+    @Override
+    public final SearchModule create(Activity activity, ResultUpdateListener<ListItem> updateListener, ItemChosenAction<ITEM_DATA> itemChosenAction)
+    {
+        AppPermissions appPermissions = new BasicAppPermissions(activity);
+        Permission permission = appPermissions.forName(mPermissionName);
+
+        if (!permission.isRequestable(activity))
+        {
+            return new NoOpSearchModule();
+        }
+
+        SearchModule delegateModule = mDelegateModuleFactory.create(activity, updateListener, itemChosenAction);
+
+        return new PermissionProxy(
+                activity,
+                delegateModule,
+                mQueryPredicate,
+                updateListener,
+                permission,
+                activity.getString(mNotAskedYetMessage),
+                activity.getString(mDeniedMessage),
+                activity.getString(mDeniedWithNeverAskAgainMessage));
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/permissionproxy/PermissionProxy.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/permissionproxy/PermissionProxy.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.searchlist.permissionproxy;
+
+import android.app.Activity;
+import android.support.annotation.Nullable;
+
+import com.schedjoules.eventdiscovery.framework.list.ListItem;
+import com.schedjoules.eventdiscovery.framework.list.smart.Clickable;
+import com.schedjoules.eventdiscovery.framework.location.listitems.MessageItem;
+import com.schedjoules.eventdiscovery.framework.permissions.Permission;
+import com.schedjoules.eventdiscovery.framework.searchlist.SearchModule;
+import com.schedjoules.eventdiscovery.framework.searchlist.SearchModuleFactory;
+import com.schedjoules.eventdiscovery.framework.searchlist.predicate.QueryPredicate;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.Clear;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.ResultUpdateListener;
+import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.ShowSingle;
+import com.schedjoules.eventdiscovery.framework.utils.smartview.OnClickAction;
+
+
+/**
+ * A {@link SearchModule} control proxy to use before another module that requires a permission to operate. It shows appropriate messages and prompts user to
+ * grant the permission.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class PermissionProxy implements SearchModule
+{
+    private final Activity mActivity;
+    private final SearchModule mDelegate;
+    private final QueryPredicate mQueryPredicate;
+    private final ResultUpdateListener<ListItem> mUpdateListener;
+    private final Permission mPermission;
+    private final String mNotAskedYetMessage;
+    private final String mDeniedMessage;
+    private final String mDeniedWithNeverAskAgainMessage;
+    private boolean mPermissionRequested;
+
+
+    /**
+     * Constructor.
+     *
+     * @param activity
+     *         The current {@link Activity}.
+     * @param delegate
+     *         the delegate module to dispatch queries to if the permission is granted
+     * @param queryPredicate
+     *         tells which queries are relevant to the delegate module, so permission request message items are not shown when queries are not relevant
+     * @param updateListener
+     *         see {@link SearchModuleFactory} for more
+     * @param permission
+     *         the permission that is required for the delegate module to operate
+     * @param notAskedYetMessage
+     *         the message that should be displayed as an item when the permission hasn't been asked yet
+     * @param deniedMessage
+     *         the message that should be displayed as an item when the permission has been denied
+     * @param deniedWithNeverAskAgainMessage
+     *         the message that should be displayed as an item when the permission has been denied with "Never ask again" checked
+     */
+    public PermissionProxy(Activity activity,
+                           SearchModule delegate,
+                           QueryPredicate queryPredicate,
+                           ResultUpdateListener<ListItem> updateListener,
+                           Permission permission,
+                           String notAskedYetMessage,
+                           String deniedMessage,
+                           String deniedWithNeverAskAgainMessage)
+    {
+        mActivity = activity;
+        mDelegate = delegate;
+        mQueryPredicate = queryPredicate;
+        mUpdateListener = updateListener;
+        mPermission = permission;
+        mNotAskedYetMessage = notAskedYetMessage;
+        mDeniedMessage = deniedMessage;
+        mDeniedWithNeverAskAgainMessage = deniedWithNeverAskAgainMessage;
+    }
+
+
+    @Override
+    public void shutDown()
+    {
+    }
+
+
+    @Override
+    public void onSearchQueryChange(String newQuery)
+    {
+        if (!mQueryPredicate.isValid(newQuery))
+        {
+            mUpdateListener.onUpdate(new Clear<ListItem>(newQuery));
+        }
+        else
+        {
+            if (mPermission.isGranted())
+            {
+                mDelegate.onSearchQueryChange(newQuery);
+            }
+            else
+            {
+                if (mPermissionRequested)
+                {
+                    Activity activity = mActivity;
+                    if (activity != null && mPermission.isRequestable(activity))
+                    {
+                        showMessageItem(mDeniedMessage, new PermissionRequestOnClick(), newQuery);
+                    }
+                    else
+                    {
+                        showMessageItem(mDeniedWithNeverAskAgainMessage, null, newQuery);
+                    }
+                }
+                else
+                {
+                    showMessageItem(mNotAskedYetMessage, new PermissionRequestOnClick(), newQuery);
+                }
+            }
+        }
+    }
+
+
+    private void showMessageItem(String message, @Nullable OnClickAction onClickAction, String query)
+    {
+        ListItem messageItem = onClickAction == null ?
+                new MessageItem(message) : new Clickable<>(new MessageItem(message), onClickAction);
+        mUpdateListener.onUpdate(new ShowSingle<>(messageItem, query));
+    }
+
+
+    private class PermissionRequestOnClick implements OnClickAction
+    {
+        @Override
+        public void onClick()
+        {
+            mPermissionRequested = true;
+            mPermission.request().send(mActivity);
+        }
+
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/predicate/EmptyQueryPredicate.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/predicate/EmptyQueryPredicate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.searchlist.predicate;
+
+/**
+ * {@link QueryPredicate} that validates for empty strings.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class EmptyQueryPredicate implements QueryPredicate
+{
+
+    @Override
+    public boolean isValid(String query)
+    {
+        return query.isEmpty();
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/predicate/QueryPredicate.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/predicate/QueryPredicate.java
@@ -15,21 +15,18 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.searchlist;
+package com.schedjoules.eventdiscovery.framework.searchlist.predicate;
 
 /**
- * Listener interface for components that handle {@link ResultUpdate}s.
+ * A general predicate for checking whether a query is valid in a certain context or not.
  *
  * @author Gabor Keszthelyi
  */
-public interface ResultUpdateListener<T>
+public interface QueryPredicate
 {
 
     /**
-     * Called from {@link SearchModule} then it wants to update its section in the list.
-     *
-     * @param update
-     *         and update to the section of the list
+     * Tells whether the given query is valid in the given context or not.
      */
-    void onUpdate(ResultUpdate<T> update);
+    boolean isValid(String query);
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/Clear.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/Clear.java
@@ -15,28 +15,31 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.searchlist;
+package com.schedjoules.eventdiscovery.framework.searchlist.resultupdates;
 
+import com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.ClearAll;
 import com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.NonNotifyingChangeableList;
 
 
 /**
- * Represents and update to a section of a search list. {@link SearchModule}s can create these and pass on to {@link ResultUpdateListener}.
+ * {@link ResultUpdate} to clear all items if the current query string still matches.
  *
  * @author Gabor Keszthelyi
  */
-public interface ResultUpdate<T>
+public final class Clear<T> implements ResultUpdate<T>
 {
+    private final String mQuery;
 
-    /**
-     * Applies the changes of this update to the given list.
-     * <p>
-     * Depending on the update it can check if currentQuery matches the query this update belongs to and discard if it doesn't.
-     *
-     * @param changeableList
-     *         the changeable list representing a section of the whole list
-     * @param currentQuery
-     *         the current (last) query entered by the user
-     */
-    void apply(NonNotifyingChangeableList<T> changeableList, String currentQuery);
+
+    public Clear(String query)
+    {
+        mQuery = query;
+    }
+
+
+    @Override
+    public void apply(NonNotifyingChangeableList<T> changeableList, String currentQuery)
+    {
+        new SearchResultUpdate<>(new ClearAll<T>(), mQuery).apply(changeableList, currentQuery);
+    }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/ReplaceAll.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/ReplaceAll.java
@@ -15,36 +15,36 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.searchlist;
+package com.schedjoules.eventdiscovery.framework.searchlist.resultupdates;
 
 import com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.NonNotifyingChangeableList;
-import com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.NonNotifyingListChange;
+
+import java.util.List;
 
 
 /**
- * {@link ResultUpdate} for a search result. It doesn't apply itself if the query has been changed in the meantime.
+ * {@link ResultUpdate} to replace all items with the given ones, if the current query string still matches.
  *
  * @author Gabor Keszthelyi
  */
-public final class SearchResultUpdate<T> implements ResultUpdate<T>
+public final class ReplaceAll<T> implements ResultUpdate<T>
 {
-    private final NonNotifyingListChange<T> mNonNotifyingListChange;
+    private final List<T> mItems;
     private final String mQuery;
 
 
-    public SearchResultUpdate(NonNotifyingListChange<T> nonNotifyingListChange, String query)
+    public ReplaceAll(List<T> items, String query)
     {
-        mNonNotifyingListChange = nonNotifyingListChange;
+        mItems = items;
         mQuery = query;
     }
 
 
     @Override
-    public void apply(NonNotifyingChangeableList<T> list, String currentQuery)
+    public void apply(NonNotifyingChangeableList<T> changeableList, String currentQuery)
     {
-        if (currentQuery.equals(mQuery))
-        {
-            list.apply(mNonNotifyingListChange);
-        }
+        new SearchResultUpdate<>(
+                new com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.ReplaceAll<>(mItems), mQuery)
+                .apply(changeableList, currentQuery);
     }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/ResultUpdate.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/ResultUpdate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.searchlist.resultupdates;
+
+import com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.NonNotifyingChangeableList;
+import com.schedjoules.eventdiscovery.framework.searchlist.SearchModule;
+
+
+/**
+ * Represents and update to a section of a search list. {@link SearchModule}s can create these and pass on to {@link ResultUpdateListener}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public interface ResultUpdate<T>
+{
+
+    /**
+     * Applies the changes of this update to the given list.
+     * <p>
+     * Depending on the update it can check if currentQuery matches the query this update belongs to and discard if it doesn't.
+     *
+     * @param changeableList
+     *         the changeable list representing a section of the whole list
+     * @param currentQuery
+     *         the current (last) query entered by the user
+     */
+    void apply(NonNotifyingChangeableList<T> changeableList, String currentQuery);
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/ResultUpdateListener.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/ResultUpdateListener.java
@@ -15,18 +15,24 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.model;
+package com.schedjoules.eventdiscovery.framework.searchlist.resultupdates;
+
+import com.schedjoules.eventdiscovery.framework.searchlist.SearchModule;
+
 
 /**
- * Represents a place (city, venue, place) with a name and identifier.
+ * Listener interface for components that handle {@link ResultUpdate}s.
  *
  * @author Gabor Keszthelyi
  */
-public interface NamedPlace
+public interface ResultUpdateListener<T>
 {
-    String id();
 
-    CharSequence name();
-
-    CharSequence extraContext();
+    /**
+     * Called from {@link SearchModule} then it wants to update its section in the list.
+     *
+     * @param update
+     *         and update to the section of the list
+     */
+    void onUpdate(ResultUpdate<T> update);
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/SearchResultUpdate.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/SearchResultUpdate.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.searchlist.resultupdates;
+
+import com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.NonNotifyingChangeableList;
+import com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.NonNotifyingListChange;
+
+
+/**
+ * {@link ResultUpdate} for a search result. It doesn't apply itself if the query has been changed in the meantime.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class SearchResultUpdate<T> implements ResultUpdate<T>
+{
+    private final NonNotifyingListChange<T> mNonNotifyingListChange;
+    private final String mQuery;
+
+
+    public SearchResultUpdate(NonNotifyingListChange<T> nonNotifyingListChange, String query)
+    {
+        mNonNotifyingListChange = nonNotifyingListChange;
+        mQuery = query;
+    }
+
+
+    @Override
+    public void apply(NonNotifyingChangeableList<T> list, String currentQuery)
+    {
+        if (currentQuery.equals(mQuery))
+        {
+            list.apply(mNonNotifyingListChange);
+        }
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/SectionedResultUpdateListener.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/SectionedResultUpdateListener.java
@@ -15,23 +15,21 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.utils;
+package com.schedjoules.eventdiscovery.framework.searchlist.resultupdates;
 
-import android.view.View;
+import com.schedjoules.eventdiscovery.framework.searchlist.SearchModule;
 
 
 /**
- * Interface that can be implemented by any {@link View} that is 'smart', i.e. it takes care of how to update itself
- * from data/model and may also initiate actions, when clicked for example, instead of calling back.
+ * Listener interface for components that handle {@link ResultUpdate} marked with section numbers.
  *
  * @author Gabor Keszthelyi
  */
-public interface SmartView<T>
+public interface SectionedResultUpdateListener<T>
 {
 
     /**
-     * Called to update the View's content with the provided data.
+     * Called when a {@link SearchModule} with the given <code>sectionNumber</code> requests the given update to its section.
      */
-    void update(T data);
-
+    void onUpdate(int sectionNumber, ResultUpdate<T> update);
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/SectionedResultUpdateListenerAdapter.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/SectionedResultUpdateListenerAdapter.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.searchlist;
+package com.schedjoules.eventdiscovery.framework.searchlist.resultupdates;
 
 /**
  * Adapts {@link ResultUpdateListener} to {@link SectionedResultUpdateListener}.

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/ShowSingle.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/ShowSingle.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.searchlist.resultupdates;
+
+import com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.NonNotifyingChangeableList;
+import com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.ReplaceAll;
+
+
+/**
+ * {@link ResultUpdate} to show the given item only, if the current query string still matches.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class ShowSingle<T> implements ResultUpdate<T>
+{
+    private final T mItem;
+    private final String mQuery;
+
+
+    public ShowSingle(T item, String query)
+    {
+        mItem = item;
+        mQuery = query;
+    }
+
+
+    @Override
+    public void apply(NonNotifyingChangeableList<T> changeableList, String currentQuery)
+    {
+        new SearchResultUpdate<>(new ReplaceAll<>(mItem), mQuery).apply(changeableList, currentQuery);
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/Broadcast.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/Broadcast.java
@@ -15,21 +15,21 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.list;
+package com.schedjoules.eventdiscovery.framework.utils;
+
+import android.content.Context;
+
 
 /**
- * Action that can be executed when a list item was selected.
+ * Represents an Android broadcast.
  *
  * @author Gabor Keszthelyi
  */
-public interface ListItemSelectionAction<T>
+public interface Broadcast
 {
 
     /**
-     * Called when the item was selected by the user.
-     *
-     * @param itemData
-     *         the data corresponding to the list item
+     * Sends the broadcast.
      */
-    void onItemSelected(T itemData);
+    void send(Context context);
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/cache/Cache.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/cache/Cache.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.cache;
+
+import com.schedjoules.eventdiscovery.framework.model.Equalable;
+
+
+/**
+ * Interface for a simple cache.
+ *
+ * @author Gabor Keszthelyi
+ */
+public interface Cache<K extends Equalable, V>
+{
+    /**
+     * Gets the value stored for the given key or null if missing.
+     */
+    V get(K key);
+
+    /**
+     * Stores the given key-value pair in the cache.
+     */
+    void put(K key, V value);
+
+    /**
+     * Clears all entries from the cache.
+     */
+    void clear();
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/cache/TimedSingleValueCache.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/cache/TimedSingleValueCache.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.cache;
+
+import com.schedjoules.eventdiscovery.framework.model.Equalable;
+
+import org.dmfs.rfc5545.Duration;
+
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * {@link Cache} that holds a single value for a specified expiration time.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class TimedSingleValueCache<K extends Equalable, V> implements Cache<K, V>
+{
+    private final long mExpiryTime;
+
+    private long mLastPutTime;
+
+    private K mKey;
+    private V mValue;
+
+
+    public TimedSingleValueCache(long expiryTime, TimeUnit timeUnit)
+    {
+        mExpiryTime = timeUnit.toMillis(expiryTime);
+    }
+
+
+    public TimedSingleValueCache(Duration expiryDuration)
+    {
+        mExpiryTime = expiryDuration.toMillis();
+    }
+
+
+    @Override
+    public V get(K key)
+    {
+        if (System.currentTimeMillis() - mLastPutTime > mExpiryTime)
+        {
+            clear();
+            return null;
+        }
+
+        if (mKey != null && mKey.equals(key))
+        {
+            return mValue;
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+
+    @Override
+    public void put(K key, V value)
+    {
+        mKey = key;
+        mValue = value;
+        mLastPutTime = System.currentTimeMillis();
+    }
+
+
+    @Override
+    public void clear()
+    {
+        mKey = null;
+        mValue = null;
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/factory/Caching.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/factory/Caching.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.factory;
+
+/**
+ * Caching decorator for {@link Factory}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class Caching<T> implements Factory<T>
+{
+    private final Factory<T> mDelegate;
+
+    private T mInstance;
+
+
+    public Caching(Factory<T> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public T create()
+    {
+        if (mInstance == null)
+        {
+            mInstance = mDelegate.create();
+        }
+        return mInstance;
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/factory/Factory.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/factory/Factory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.factory;
+
+/**
+ * General factory interface.
+ *
+ * @author Gabor Keszthelyi
+ */
+public interface Factory<T>
+{
+    /**
+     * Create the object.
+     */
+    T create();
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/smartview/OnClickAction.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/smartview/OnClickAction.java
@@ -15,18 +15,17 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.searchlist;
+package com.schedjoules.eventdiscovery.framework.utils.smartview;
 
 /**
- * Listener interface for components that handle {@link ResultUpdate} marked with section numbers.
+ * An action that can be executed when a UI element is clicked by the user.
  *
  * @author Gabor Keszthelyi
  */
-public interface SectionedResultUpdateListener<T>
+public interface OnClickAction
 {
-
     /**
-     * Called when a {@link SearchModule} with the given <code>sectionNumber</code> requests the given update to its section.
+     * Called when the UI element has been clicked.
      */
-    void onUpdate(int sectionNumber, ResultUpdate<T> update);
+    void onClick();
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/smartview/SmartView.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/smartview/SmartView.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.smartview;
+
+import android.view.View;
+
+
+/**
+ * Interface that can be implemented by any {@link View} that is 'smart', i.e. that takes care of how to update itself
+ * from data/model and may also initiate actions, when clicked for example, instead of calling back.
+ *
+ * @author Gabor Keszthelyi
+ */
+public interface SmartView<D>
+{
+
+    /**
+     * Called to update the View's content with the provided data.
+     */
+    void update(D data);
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/strings/BasicStrings.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/strings/BasicStrings.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.strings;
+
+import android.content.Context;
+import android.support.annotation.StringRes;
+
+
+/**
+ * Basic implementation for {@link Strings}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class BasicStrings implements Strings
+{
+    private final Context mAppContext;
+
+
+    public BasicStrings(Context context)
+    {
+        mAppContext = context.getApplicationContext();
+    }
+
+
+    @Override
+    public String get(@StringRes int resId)
+    {
+        return mAppContext.getString(resId);
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/strings/Strings.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/strings/Strings.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.strings;
+
+import android.content.Context;
+import android.support.annotation.StringRes;
+
+
+/**
+ * Accesses string resources.
+ *
+ * @author Gabor Keszthelyi
+ */
+public interface Strings
+{
+    /**
+     * See {@link Context#getString(int)}
+     */
+    String get(@StringRes int resId);
+}

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_list_item_location_message.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_list_item_location_message.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.schedjoules.eventdiscovery.framework.location.listitems.MessageItemView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="@dimen/schedjoules_location_list_item_height"
+        android:focusable="true"
+        android:background="?attr/selectableItemBackground">
+
+    <TextView
+            android:id="@+id/schedjoules_place_message_item_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
+            android:paddingLeft="24dp"
+            android:paddingRight="24dp"
+            android:textSize="16sp"
+            android:gravity="left|center_vertical"
+            android:layout_centerVertical="true"/>
+
+    <View
+            android:layout_height="1px"
+            android:layout_width="match_parent"
+            android:background="@color/schedjoules_divider"
+            android:layout_alignParentBottom="true"/>
+
+</com.schedjoules.eventdiscovery.framework.location.listitems.MessageItemView>

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_list_item_place_suggestion.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_list_item_place_suggestion.xml
@@ -3,9 +3,9 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:minHeight="@dimen/schedjoules_location_list_item_height"
         android:focusable="true"
-        android:background="?attr/selectableItemBackground"
-        android:orientation="vertical">
+        android:background="?attr/selectableItemBackground">
 
     <TextView
             android:id="@+id/schedjoules_place_suggestion_item_name"
@@ -22,6 +22,7 @@
             android:id="@+id/schedjoules_location_suggestion_item_extra_context"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_below="@id/schedjoules_place_suggestion_item_name"
             android:paddingLeft="24dp"
             android:paddingRight="24dp"
             android:paddingTop="1dp"
@@ -29,6 +30,10 @@
             android:textSize="12sp"
             android:gravity="left|center_vertical"/>
 
-    <include layout="@layout/schedjoules_list_item_divider"/>
+    <View
+            android:layout_height="1px"
+            android:layout_width="match_parent"
+            android:background="@color/schedjoules_divider"
+            android:layout_alignParentBottom="true"/>
 
 </com.schedjoules.eventdiscovery.framework.location.listitems.PlaceSuggestionItemView>

--- a/eventdiscovery-sdk/src/main/res/values-de/strings.xml
+++ b/eventdiscovery-sdk/src/main/res/values-de/strings.xml
@@ -45,4 +45,12 @@
 
     <string name="schedjoules_today">Heute</string>
     <string name="schedjoules_tomorrow">Morgen</string>
+
+    <string name="schedjoules_location_picker_current_location">Mein Standort</string>
+    <string name="schedjoules_location_picker_current_location_locating">Standort wird ermittelt…</string>
+    <string name="schedjoules_location_picker_current_location_permission_rationale">Bitte erlaube den Zugriff auf deinen Standort um diese Funkionen nutzen zu können.</string>
+    <string name="schedjoules_location_picker_current_location_permission_inform_about_phone_settings">Bitte erteile die Standort Berechtigung in den Systemeinstellungen um diese Funktion später nutzen zu können.</string>
+    <string name="schedjoules_location_picker_current_location_error">Dein Standort konnte nicht ermittelt werden. Hier tippen um es erneut zu versuchen.</string>
+    <string name="schedjoules_location_picker_caption_place_suggestions">Vorschläge</string>
+    <string name="schedjoules_location_picker_caption_recent_locations">Zuletzt gesucht</string>
 </resources>

--- a/eventdiscovery-sdk/src/main/res/values-nl/strings.xml
+++ b/eventdiscovery-sdk/src/main/res/values-nl/strings.xml
@@ -29,4 +29,12 @@
 
     <string name="schedjoules_today">Vandaag</string>
     <string name="schedjoules_tomorrow">Morgen</string>
+
+    <string name="schedjoules_location_picker_current_location">Huidige locatie</string>
+    <string name="schedjoules_location_picker_current_location_locating">Locatie zoeken…</string>
+    <string name="schedjoules_location_picker_current_location_permission_rationale">Om uw huidige locatie te kunnen gebruiken, geeft u toegang tot uw locatie.</string>
+    <string name="schedjoules_location_picker_current_location_permission_inform_about_phone_settings">Om weergave van uw huidige locatie later mogelijk te maken, geeft u toegang tot uw locatie in de instellingen van uw toestel.</string>
+    <string name="schedjoules_location_picker_current_location_error">Het is niet gelukt om uw locatie te bepalen. Klik om het opnieuw te proberen.</string>
+    <string name="schedjoules_location_picker_caption_place_suggestions">Suggesties</string>
+    <string name="schedjoules_location_picker_caption_recent_locations">Recente locaties</string>
 </resources>

--- a/eventdiscovery-sdk/src/main/res/values/dimens.xml
+++ b/eventdiscovery-sdk/src/main/res/values/dimens.xml
@@ -15,5 +15,7 @@
     <dimen name="schedjoules_event_list_progress_bar">36dp</dimen>
     <dimen name="schedjoules_event_detail_item_icon">28dp</dimen>
 
+    <dimen name="schedjoules_location_list_item_height">64dp</dimen>
+
     <dimen name="schedjoules_toolbar_title_font_size">20dp</dimen>
 </resources>

--- a/eventdiscovery-sdk/src/main/res/values/strings.xml
+++ b/eventdiscovery-sdk/src/main/res/values/strings.xml
@@ -37,5 +37,21 @@
     <string name="schedjoules_today">Today</string>
     <string name="schedjoules_tomorrow">Tomorrow</string>
 
-    <string name="schedjoules_location_picker_place_suggestions_title">Suggestions</string>
+    <!-- Location picker screen: -->
+
+    <!-- Location picker list item name for current location of the user/device -->
+    <string name="schedjoules_location_picker_current_location">Current location</string>
+    <!-- Progress list item displayed during retrieving the current location -->
+    <string name="schedjoules_location_picker_current_location_locating">Find location…</string>
+    <!-- List message item displayed in place of current location after user denied to give permission to access their location on the system dialog. -->
+    <string name="schedjoules_location_picker_current_location_permission_rationale">To use your current location, please allow access to your location.</string>
+    <!-- List message item displayed in place of current location after user denied to give permission to access their location on the system dialog and also checked "Never show again" checkbox. (They can only give the permission from phone settings after that.)-->
+    <string name="schedjoules_location_picker_current_location_permission_inform_about_phone_settings">To later enable current location display, allow access to your location from your device settings.</string>
+    <!-- Error message list item displayed in place of current location when there was some error during retrieving the location. -->
+    <string name="schedjoules_location_picker_current_location_error">We could not determine your location. Please tap to retry.</string>
+    <!-- The title above the list items for place suggestions, i.e. suggestions retrieved from Google based on the text the user types.-->
+    <string name="schedjoules_location_picker_caption_place_suggestions">Suggestions</string>
+    <!-- The title above the list of recently selected location. -->
+    <string name="schedjoules_location_picker_caption_recent_locations">Recent locations</string>
+
 </resources>


### PR DESCRIPTION
@dmfs It’s ready for a first review.

TODOs, questions, notes (updated continuously):

- [x] 1. Review and test different Android and targetSdk usage again, also with manifest merge exclusion. (not fully, see item 18.)

- [ ] 2. Update Wiki with this location permission topic. -> update on branch `location-picker/95-current-location` of the wiki repository, needs review and merge

- [x] 3. When the user denies the permission (or had denied the permission earlier) with the "Never ask again" checkbox selected, then we need to hide the Current Location module.

- [x] 4. In order to not fetch the city every time it is shown, i.e. when user clears the search query, I plan to add a simple caching with a few minutes expiration time

- [ ] 5. Translations for new string resources

- [x] 6. In the current way, the last known geo location of the phone is used to fetch corresponding `Address`es with `Geocoder`, and city and country is taken from the first `Address`. The resulting `GeoPlace` will have this geo location as coordinates, so this will not be the same as the one which would have been used from a `AutocompletePrediction`, so when user selects the same city from suggestions.
So the event discovery will have different center of radius.
I've also deliberately added the geo location to the `id()` field of `GeoPlace`, so even two 'current location' city will not be equal if there is any change in last known geo location.
Just thinking now that it may cause problem with 'Recent Location', showing the same city multiple times.
So we probably need to figure this out. Any suggestions?
-> Will be handled with different `Equalable` decorators probably later. Also we may not need to store current location selections in recent locations.

- [x] 7. As I mentioned on chat, I think it would be good to change `GeoPlace` so that it extends `NamedPlace` and `GeoLocation` and not composed of them. What do you think? If you agree, when should we do it? -> good like this

- [x] 8. I've introduced a general onClick action handling for `SmartView`s, please check it out if it looks good to you. In particular, what I don't really like currently that all `ClickeableSmartView`s, in order to implement the `setOnClickAction`, has to store the data, and also that listener setup is repeating over them. See `MessageItemView` for example. -> update as discussed on the call

- [x] 9. A general note, that we are generating many objects in this search list currently. It's partly because of the declarative design around these `change`s and their decorators/adapters, and also because all modules always react to a new query (current location always sends a `Clear` update when query is not empty). There are a couple of classes which we could have a single instance.
A bit unrelated, but the change aggregation will also be still there as an optimization possibility.
So let me know if we should spend any time now to look through the code from this point of view or if you think it's fine. -> not a concern

- [x] 10. Currently after locating the city, it is not selected automatically as in the story, but displayed first, so user has to to select it. I think it’s better this way, it gives a clear feedback that we located him, what city we located and then he can actually confirm by pressing it that it’s right, this is where I am, this is where I want to search. It is also more in line with the general usage of the screen. (We may have nearby places later for example.)
What do you think? -> fine this way

- [x] 11. Review current location permission 'flow' and related user messages. Should we do something differently? Please check starting typing, erasing, and switching permission in phone settings.
Should we maybe add an ‘X’ button to messages displayed after user has denied the permission? I think for the last one that informs them to go to phone settings should definitely have an 'X'.
If we add 'X' to the first denied message, too, the question is whether to show the Current Location module next time.
Should we maybe add it to this error message item as well, to inactivate the module for the time of the current activity?
_“Failed to get the location. Tap to retry.”_

- [x] 12. I’ve added and started to use this `Equalable` interface as mentioned. Your suggestion is a bit different, so we need to get back to this, discuss it, and update.
Separate ad-hoc technical story? -> will be handled it separate story

- [x] 13. Possible generalization of `LocationPermissionProxy`  - I don't know at this point that it's worth it, handling might be special to module, but we should at least do it until 11. is finalized. -> generalized

- [x] 14. TODO at `PlaceSuggestionModule.java:141` for code improvement

- [x] 15. Android `Location` uses `double` for latlng while we use `float` so there is conversion (in both direction). Could it cause any problem when comparing? Considering using `double` on server as well, given that google is used there as well?

- [x] 16. I plan to move `framework.location.model` package to `framework.model.location` and rename `framework.location` to `framework.locationpicker`. Okay to do it now, or postpone it because of possible code conflicts with other story? -> will be listed as new story

- [x] 17. The `FourWayPermissionStatus` now handles the case when the manifest doesn't contain the permission (it was removed) as well. Should we make a `FiveWayPermissionStatus` with an extra `NOT_IN_MANIFEST` status? That case is now mapped to `DENIED_WITH_NEVER_ASK_AGAIN`, which is mostly good, but this 5th one might be useful to know not to ever advise the user to grant the permission from phone settings, because they can't. It is not a big effort to add this. -> updated to `FiveWay` with `NOT_IN_MANIFEST`.

- [x] 18. Testing the app installation permission request on API level < 23 device. I couldn't do it with the emulator, simply can't find the apk file I put on the emulator. It has no file explorer, just 'Downloads' app, that doesn't show it even though I put it in sdcard/dowloads. The file can be seen however from 'Settings/Storage/Misc', but that it can be 'executed'.

- [x] 19. Create story for Equalable stuff -> https://github.com/schedjoules/android-event-discovery-sdk/issues/129

- [x] 20. Create story for UI, UX improvements that are not critical, like animating dots on "Locating..." and animating showing up the found location. (Depends on the review)

- [x] 21. Create story for package refactors, moving classes:
Move `framework.location.model` package to `framework.model.location` and rename `framework.location` to `framework.locationpicker`. Move modules related classes in `framework.locationpicker` to subpackage `modules`. -> created: https://github.com/schedjoules/android-event-discovery-sdk/issues/130

- [x] 22. See if it's worth adding and extra layer above permission broadcast handling. Some of the code in the `BroadcastReceiver` would be repeated in other `Permission`s. See TODO there.
-> I tried a few ways, none of them was totally clear, so I kept it like this for now, if we have a new Permission, we can look at it again

- [x] 23. Possibly create a story to use center of the city as geo location when selecting current location instead of the last known location of the phone. It may be possible to do it relatviely easy with an extra call to `getFromLocationName()` of `GeoCoder`.