### PR TITLE
PR for 134: error handling in location picker

### DIFF
--- a/eventdiscovery-sdk/src/androidTest/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListAutomatedAndroidTest.java
+++ b/eventdiscovery-sdk/src/androidTest/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListAutomatedAndroidTest.java
@@ -58,7 +58,7 @@ import static java.util.Arrays.asList;
  * @author Gabor Keszthelyi
  */
 @RunWith(AndroidJUnit4.class)
-public class EventListAutomatedAndroidTest
+public final class EventListAutomatedAndroidTest
 {
     // Set to other than zero if you want to watch the test
     private static int WATCH_BREAK_MILLIS = 0;

--- a/eventdiscovery-sdk/src/androidTest/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListManualAndroidTest.java
+++ b/eventdiscovery-sdk/src/androidTest/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListManualAndroidTest.java
@@ -52,7 +52,7 @@ import static java.util.Arrays.asList;
  */
 @Suppress // Comment this annotation out to run the manual testing
 @RunWith(AndroidJUnit4.class)
-public class EventListManualAndroidTest
+public final class EventListManualAndroidTest
 {
     @Rule
     public ActivityTestRule<LauncherTestActivity> mActivityTestRule =

--- a/eventdiscovery-sdk/src/androidTest/java/com/schedjoules/eventdiscovery/framework/model/recent/SerializableCharSequenceConverterTest.java
+++ b/eventdiscovery-sdk/src/androidTest/java/com/schedjoules/eventdiscovery/framework/model/recent/SerializableCharSequenceConverterTest.java
@@ -31,7 +31,7 @@ import static junit.framework.Assert.assertEquals;
  * @author Marten Gajda
  */
 @RunWith(AndroidJUnit4.class)
-public class SerializableCharSequenceConverterTest
+public final class SerializableCharSequenceConverterTest
 {
     @Test
     public void testStringSerializable() throws Exception

--- a/eventdiscovery-sdk/src/androidTest/java/com/schedjoules/eventdiscovery/testutils/mockapi/MockPagesSetupBuilder.java
+++ b/eventdiscovery-sdk/src/androidTest/java/com/schedjoules/eventdiscovery/testutils/mockapi/MockPagesSetupBuilder.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * Generated with 'Replace constructor with builder' IntelliJ action for {@link MockPagesSetup}.
  */
-public class MockPagesSetupBuilder
+public final class MockPagesSetupBuilder
 {
     private DateTime mFirstEventTime;
     private Duration mIntervalBetweenEvents;

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/flexibleadapter/Copying.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/flexibleadapter/Copying.java
@@ -34,7 +34,7 @@ import eu.davidea.flexibleadapter.items.IFlexible;
  *
  * @author Gabor Keszthelyi
  */
-public class Copying implements Factory<FlexibleAdapter<IFlexible>>
+public final class Copying implements Factory<FlexibleAdapter<IFlexible>>
 {
     private final Factory<FlexibleAdapter<IFlexible>> mDelegate;
     private final FlexibleAdapter<IFlexible> mOldAdapter;

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/flexibleadapter/FlexibleAdapterFactory.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/flexibleadapter/FlexibleAdapterFactory.java
@@ -30,7 +30,7 @@ import eu.davidea.flexibleadapter.items.IFlexible;
  *
  * @author Gabor Keszthelyi
  */
-public class FlexibleAdapterFactory implements Factory<FlexibleAdapter<IFlexible>>
+public final class FlexibleAdapterFactory implements Factory<FlexibleAdapter<IFlexible>>
 {
     @Override
     public FlexibleAdapter<IFlexible> create()

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/BasicGoogleApis.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/BasicGoogleApis.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.googleapis;
+
+import android.support.v4.app.FragmentActivity;
+
+import com.google.android.gms.common.api.Api;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.schedjoules.eventdiscovery.framework.googleapis.errors.AbstractGoogleApiRequestException;
+import com.schedjoules.eventdiscovery.framework.utils.factory.Factory;
+import com.schedjoules.eventdiscovery.framework.utils.factory.Lazy;
+import com.schedjoules.eventdiscovery.framework.utils.factory.ThreadSafeLazy;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+
+/**
+ * Basic implementation for {@link GoogleApis}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public class BasicGoogleApis implements GoogleApis
+{
+    private static int clientIdCounter = 1264;
+
+    private final FragmentActivity mActivity;
+    private final Set<Api> mApis;
+
+    private Lazy<GoogleApiClient> mGoogleApiClient;
+
+
+    public BasicGoogleApis(FragmentActivity activity, Api... apis)
+    {
+        mActivity = activity;
+        mApis = Collections.synchronizedSet(new HashSet<>(Arrays.asList(apis)));
+        mGoogleApiClient = new ThreadSafeLazy<>(new GoogleApiClientFactory());
+    }
+
+
+    @Override
+    public <T> T execute(GoogleApiRequest<T> request) throws AbstractGoogleApiRequestException
+    {
+        if (!mApis.contains(request.requiredApi()))
+        {
+            mApis.add(request.requiredApi());
+            mGoogleApiClient = new ThreadSafeLazy<>(new GoogleApiClientFactory());
+        }
+        return request.execute(mGoogleApiClient.get());
+    }
+
+
+    private final class GoogleApiClientFactory implements Factory<GoogleApiClient>
+    {
+
+        @Override
+        public GoogleApiClient create()
+        {
+            GoogleApiClient.Builder builder = new GoogleApiClient.Builder(mActivity);
+            for (Api api : mApis)
+            {
+                builder.addApiIfAvailable(api);
+            }
+            builder.enableAutoManage(mActivity, clientIdCounter++, null);
+            return builder.build();
+        }
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/Connected.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/Connected.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.googleapis;
+
+import com.schedjoules.eventdiscovery.framework.googleapis.errors.AbstractGoogleApiRequestException;
+import com.schedjoules.eventdiscovery.framework.googleapis.requests.ConnectionErrorHandling;
+
+
+/**
+ * Decorator for {@link GoogleApis} that applies the {@link ConnectionErrorHandling} decorator for the request, i.e. takes care of connection errors.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class Connected implements GoogleApis
+{
+    private final GoogleApis mDelegate;
+
+
+    public Connected(GoogleApis delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public <T> T execute(GoogleApiRequest<T> request) throws AbstractGoogleApiRequestException
+    {
+        return mDelegate.execute(new ConnectionErrorHandling<>(request));
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/GoogleApiRequest.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/GoogleApiRequest.java
@@ -15,30 +15,28 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
+package com.schedjoules.eventdiscovery.framework.googleapis;
 
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
+import com.google.android.gms.common.api.Api;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.schedjoules.eventdiscovery.framework.googleapis.errors.AbstractGoogleApiRequestException;
 
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * Request that can be executed by {@link GoogleApis}.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public interface GoogleApiRequest<T>
 {
+    /**
+     * Executes this request.
+     */
+    T execute(GoogleApiClient googleApiClient) throws AbstractGoogleApiRequestException;
 
-    public MessageItem(CharSequence text)
-    {
-        super(text, R.layout.schedjoules_list_item_location_message);
-    }
+    /**
+     * Returns the Google {@link Api} that is needed for this request to be executed.
+     */
+    Api requiredApi();
 
-
-    @Override
-    protected String toStringLabel()
-    {
-        return "MessageItem";
-    }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/GoogleApis.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/GoogleApis.java
@@ -15,33 +15,25 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.utils.factory;
+package com.schedjoules.eventdiscovery.framework.googleapis;
+
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.schedjoules.eventdiscovery.framework.googleapis.errors.AbstractGoogleApiRequestException;
+
 
 /**
- * Caching decorator for {@link Factory}.
+ * Facade for {@link GoogleApiClient} and Google APIs.
  *
  * @author Gabor Keszthelyi
  */
-public final class Caching<T> implements Factory<T>
+public interface GoogleApis
 {
-    private final Factory<T> mDelegate;
 
-    private T mInstance;
-
-
-    public Caching(Factory<T> delegate)
-    {
-        mDelegate = delegate;
-    }
-
-
-    @Override
-    public T create()
-    {
-        if (mInstance == null)
-        {
-            mInstance = mDelegate.create();
-        }
-        return mInstance;
-    }
+    /**
+     * Executes the given request and returns the result or throws specific exceptions.
+     *
+     * @throws AbstractGoogleApiRequestException
+     *         see the subtypes for more
+     */
+    <T> T execute(GoogleApiRequest<T> request) throws AbstractGoogleApiRequestException;
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/AbstractGoogleApiRequestException.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/AbstractGoogleApiRequestException.java
@@ -15,30 +15,27 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
+package com.schedjoules.eventdiscovery.framework.googleapis.errors;
 
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
+import com.schedjoules.eventdiscovery.framework.googleapis.GoogleApis;
 
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * Abstract base type for Exceptions thrown by {@link GoogleApis}.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public abstract class AbstractGoogleApiRequestException extends Exception
 {
-
-    public MessageItem(CharSequence text)
+    public AbstractGoogleApiRequestException(String detailMessage)
     {
-        super(text, R.layout.schedjoules_list_item_location_message);
+        super(detailMessage);
     }
 
 
-    @Override
-    protected String toStringLabel()
+    public AbstractGoogleApiRequestException(String detailMessage, Throwable throwable)
     {
-        return "MessageItem";
+        super(detailMessage, throwable);
     }
+
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/BasicGoogleApiErrorInterpreter.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/BasicGoogleApiErrorInterpreter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.googleapis.errors;
+
+import com.google.android.gms.common.ConnectionResult;
+
+import static com.google.android.gms.common.ConnectionResult.API_UNAVAILABLE;
+import static com.google.android.gms.common.ConnectionResult.CANCELED;
+import static com.google.android.gms.common.ConnectionResult.DEVELOPER_ERROR;
+import static com.google.android.gms.common.ConnectionResult.INTERNAL_ERROR;
+import static com.google.android.gms.common.ConnectionResult.INTERRUPTED;
+import static com.google.android.gms.common.ConnectionResult.INVALID_ACCOUNT;
+import static com.google.android.gms.common.ConnectionResult.LICENSE_CHECK_FAILED;
+import static com.google.android.gms.common.ConnectionResult.NETWORK_ERROR;
+import static com.google.android.gms.common.ConnectionResult.RESOLUTION_REQUIRED;
+import static com.google.android.gms.common.ConnectionResult.RESTRICTED_PROFILE;
+import static com.google.android.gms.common.ConnectionResult.SERVICE_DISABLED;
+import static com.google.android.gms.common.ConnectionResult.SERVICE_INVALID;
+import static com.google.android.gms.common.ConnectionResult.SERVICE_MISSING;
+import static com.google.android.gms.common.ConnectionResult.SERVICE_MISSING_PERMISSION;
+import static com.google.android.gms.common.ConnectionResult.SERVICE_UPDATING;
+import static com.google.android.gms.common.ConnectionResult.SERVICE_VERSION_UPDATE_REQUIRED;
+import static com.google.android.gms.common.ConnectionResult.SIGN_IN_FAILED;
+import static com.google.android.gms.common.ConnectionResult.SIGN_IN_REQUIRED;
+import static com.google.android.gms.common.ConnectionResult.TIMEOUT;
+
+
+/**
+ * Basic {@link GoogleApiErrorInterpreter}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class BasicGoogleApiErrorInterpreter implements GoogleApiErrorInterpreter
+{
+    @Override
+    public boolean isRetriable(ConnectionResult connectionResult)
+    {
+        // Meaning of the codes:
+        // https://developers.google.com/android/reference/com/google/android/gms/common/ConnectionResult
+
+        switch (connectionResult.getErrorCode())
+        {
+            case API_UNAVAILABLE:
+            case LICENSE_CHECK_FAILED:
+            case SERVICE_INVALID:
+            case RESTRICTED_PROFILE:
+            case SIGN_IN_FAILED:
+            case INVALID_ACCOUNT:
+                return false;
+
+            case CANCELED:
+            case INTERNAL_ERROR:
+            case NETWORK_ERROR:
+            case SERVICE_DISABLED: // auto-managed
+            case SERVICE_MISSING: // auto-managed
+            case SERVICE_MISSING_PERMISSION: // auto-managed
+            case SERVICE_UPDATING:
+            case SERVICE_VERSION_UPDATE_REQUIRED: // auto-managed
+            case TIMEOUT:
+            case RESOLUTION_REQUIRED: // auto-managed
+            case SIGN_IN_REQUIRED: // auto-managed
+            case INTERRUPTED:
+                return true;
+
+            case DEVELOPER_ERROR:
+                throw new RuntimeException("Incorrect GoogleApiClient configuration, should not happen");
+
+                // Not applicable: SUCCESS
+
+            default:
+                return true;
+        }
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/GoogleApiAutoManagedIssueException.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/GoogleApiAutoManagedIssueException.java
@@ -15,30 +15,27 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
+package com.schedjoules.eventdiscovery.framework.googleapis.errors;
 
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
+import com.google.android.gms.common.api.GoogleApiClient;
 
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * Exception for signalling that a connection issue occurred but it resolvable and is supposedly being resolved by auto-managed {@link GoogleApiClient}.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public class GoogleApiAutoManagedIssueException extends AbstractGoogleApiRequestException
 {
-
-    public MessageItem(CharSequence text)
+    public GoogleApiAutoManagedIssueException(String detailMessage)
     {
-        super(text, R.layout.schedjoules_list_item_location_message);
+        super(detailMessage);
     }
 
 
-    @Override
-    protected String toStringLabel()
+    public GoogleApiAutoManagedIssueException(String detailMessage, Throwable throwable)
     {
-        return "MessageItem";
+        super(detailMessage, throwable);
     }
+
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/GoogleApiErrorInterpreter.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/GoogleApiErrorInterpreter.java
@@ -15,30 +15,21 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
+package com.schedjoules.eventdiscovery.framework.googleapis.errors;
 
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.api.GoogleApiClient;
 
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * Interprets {@link GoogleApiClient.OnConnectionFailedListener} callback results as retriable or not.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public interface GoogleApiErrorInterpreter
 {
-
-    public MessageItem(CharSequence text)
-    {
-        super(text, R.layout.schedjoules_list_item_location_message);
-    }
-
-
-    @Override
-    protected String toStringLabel()
-    {
-        return "MessageItem";
-    }
+    /**
+     * Tells whether the given {@link ConnectionResult} is considered a retriable error or not.
+     */
+    boolean isRetriable(ConnectionResult connectionResult);
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/GoogleApiExecutionException.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/GoogleApiExecutionException.java
@@ -15,30 +15,29 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
+package com.schedjoules.eventdiscovery.framework.googleapis.errors;
 
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.schedjoules.eventdiscovery.framework.googleapis.GoogleApiRequest;
 
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * Exception for signalling that some error happened during execution of the {@link GoogleApiRequest}.
+ * (So it's not a {@link GoogleApiClient} connection issue.)
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public class GoogleApiExecutionException extends AbstractGoogleApiRequestException
 {
-
-    public MessageItem(CharSequence text)
+    public GoogleApiExecutionException(String detailMessage)
     {
-        super(text, R.layout.schedjoules_list_item_location_message);
+        super(detailMessage);
     }
 
 
-    @Override
-    protected String toStringLabel()
+    public GoogleApiExecutionException(String detailMessage, Throwable throwable)
     {
-        return "MessageItem";
+        super(detailMessage, throwable);
     }
+
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/GoogleApiNonRecoverableException.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/GoogleApiNonRecoverableException.java
@@ -15,30 +15,27 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
+package com.schedjoules.eventdiscovery.framework.googleapis.errors;
 
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
+import com.google.android.gms.common.api.GoogleApiClient;
 
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * Exception for signalling a {@link GoogleApiClient} connection error that is non-recoverable.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public class GoogleApiNonRecoverableException extends AbstractGoogleApiRequestException
 {
-
-    public MessageItem(CharSequence text)
+    public GoogleApiNonRecoverableException(String detailMessage)
     {
-        super(text, R.layout.schedjoules_list_item_location_message);
+        super(detailMessage);
     }
 
 
-    @Override
-    protected String toStringLabel()
+    public GoogleApiNonRecoverableException(String detailMessage, Throwable throwable)
     {
-        return "MessageItem";
+        super(detailMessage, throwable);
     }
+
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/GoogleApiRecoverableException.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/errors/GoogleApiRecoverableException.java
@@ -15,30 +15,25 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
-
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
-
+package com.schedjoules.eventdiscovery.framework.googleapis.errors;
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * Exception for signalling a {@link GoogleApiClient} connection error that may be recoverable.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public class GoogleApiRecoverableException extends AbstractGoogleApiRequestException
 {
 
-    public MessageItem(CharSequence text)
+    public GoogleApiRecoverableException(String message)
     {
-        super(text, R.layout.schedjoules_list_item_location_message);
+        super(message);
     }
 
 
-    @Override
-    protected String toStringLabel()
+    public GoogleApiRecoverableException(String detailMessage, Throwable throwable)
     {
-        return "MessageItem";
+        super(detailMessage, throwable);
     }
+
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/requests/ConnectionErrorHandling.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/requests/ConnectionErrorHandling.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.googleapis.requests;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.api.Api;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.schedjoules.eventdiscovery.framework.googleapis.GoogleApiRequest;
+import com.schedjoules.eventdiscovery.framework.googleapis.errors.AbstractGoogleApiRequestException;
+import com.schedjoules.eventdiscovery.framework.googleapis.errors.BasicGoogleApiErrorInterpreter;
+import com.schedjoules.eventdiscovery.framework.googleapis.errors.GoogleApiAutoManagedIssueException;
+import com.schedjoules.eventdiscovery.framework.googleapis.errors.GoogleApiNonRecoverableException;
+import com.schedjoules.eventdiscovery.framework.googleapis.errors.GoogleApiRecoverableException;
+
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * Decorator for {@link GoogleApiRequest} that takes care of the connection errors.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class ConnectionErrorHandling<T> implements GoogleApiRequest<T>
+{
+    private final GoogleApiRequest<T> mDelegate;
+
+
+    public ConnectionErrorHandling(GoogleApiRequest<T> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public final T execute(GoogleApiClient googleApiClient) throws AbstractGoogleApiRequestException
+    {
+        ConnectionResult connectionResult = googleApiClient.blockingConnect(3, TimeUnit.SECONDS);
+        if (!connectionResult.isSuccess())
+        {
+            if (connectionResult.hasResolution())
+            {
+                // This is being auto-managed
+                throw new GoogleApiAutoManagedIssueException(connectionResult.toString());
+            }
+            else
+            {
+                if (new BasicGoogleApiErrorInterpreter().isRetriable(connectionResult))
+                {
+                    throw new GoogleApiRecoverableException(connectionResult.toString());
+                }
+                else
+                {
+                    throw new GoogleApiNonRecoverableException(connectionResult.toString());
+                }
+            }
+        }
+        return mDelegate.execute(googleApiClient);
+    }
+
+
+    @Override
+    public Api requiredApi()
+    {
+        return mDelegate.requiredApi();
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/requests/GetLastLocationRequest.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/requests/GetLastLocationRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.googleapis.requests;
+
+import android.Manifest;
+import android.location.Location;
+import android.support.annotation.RequiresPermission;
+
+import com.google.android.gms.common.api.Api;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.location.LocationServices;
+import com.schedjoules.client.eventsdiscovery.GeoLocation;
+import com.schedjoules.eventdiscovery.framework.googleapis.GoogleApiRequest;
+import com.schedjoules.eventdiscovery.framework.location.model.AndroidGeoLocation;
+
+
+/**
+ * Request to get the last known location.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class GetLastLocationRequest implements GoogleApiRequest<GeoLocation>
+{
+
+    @RequiresPermission(
+            anyOf = { Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION }
+    )
+    public GetLastLocationRequest()
+    {
+    }
+
+
+    @Override
+    public GeoLocation execute(GoogleApiClient googleApiClient)
+    {
+        @SuppressWarnings("MissingPermission")
+        Location lastLocation = LocationServices.FusedLocationApi.getLastLocation(googleApiClient);
+        if (lastLocation == null)
+        {
+            throw new RuntimeException("Last location is null");
+        }
+
+        return new AndroidGeoLocation(lastLocation);
+    }
+
+
+    @Override
+    public Api requiredApi()
+    {
+        return LocationServices.API;
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/requests/GoogleApiTask.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/requests/GoogleApiTask.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.googleapis.requests;
+
+import android.os.AsyncTask;
+
+import com.schedjoules.eventdiscovery.framework.googleapis.GoogleApiRequest;
+import com.schedjoules.eventdiscovery.framework.googleapis.GoogleApis;
+import com.schedjoules.eventdiscovery.framework.googleapis.errors.AbstractGoogleApiRequestException;
+import com.schedjoules.eventdiscovery.framework.googleapis.errors.GoogleApiExecutionException;
+
+import java.lang.ref.WeakReference;
+
+
+/**
+ * Basic {@link AsyncTask} for {@link GoogleApiRequest}s.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class GoogleApiTask<T> extends AsyncTask<GoogleApis, Void, GoogleApiTask.Result<T>>
+{
+    private final GoogleApiRequest<T> mGoogleApiRequest;
+    private final WeakReference<Callback<T>> mCallback;
+
+
+    public GoogleApiTask(GoogleApiRequest<T> googleApiRequest, Callback<T> callback)
+    {
+        mGoogleApiRequest = googleApiRequest;
+        mCallback = new WeakReference<>(callback);
+    }
+
+
+    @Override
+    protected Result<T> doInBackground(GoogleApis... googleApises)
+    {
+        try
+        {
+            return new SuccessResult<>(googleApises[0].execute(mGoogleApiRequest));
+        }
+        catch (AbstractGoogleApiRequestException e)
+        {
+            return new ExceptionResult<>(e);
+        }
+        catch (Exception e)
+        {
+            return new ExceptionResult<>(new GoogleApiExecutionException("Error during execution", e));
+        }
+    }
+
+
+    @Override
+    protected final void onPostExecute(Result<T> result)
+    {
+        Callback<T> callback = mCallback.get();
+        if (callback != null)
+        {
+            callback.onTaskFinish(result);
+        }
+    }
+
+
+    public interface Callback<T>
+    {
+        void onTaskFinish(Result<T> result);
+    }
+
+
+    public interface Result<T>
+    {
+        T value() throws AbstractGoogleApiRequestException;
+    }
+
+
+    private static final class SuccessResult<T> implements Result<T>
+    {
+        private final T mValue;
+
+
+        private SuccessResult(T value)
+        {
+            mValue = value;
+        }
+
+
+        @Override
+        public T value() throws AbstractGoogleApiRequestException
+        {
+            return mValue;
+        }
+    }
+
+
+    private static final class ExceptionResult<T> implements Result<T>
+    {
+        private final AbstractGoogleApiRequestException mException;
+
+
+        private ExceptionResult(AbstractGoogleApiRequestException exception)
+        {
+            mException = exception;
+        }
+
+
+        @Override
+        public T value() throws AbstractGoogleApiRequestException
+        {
+            throw mException;
+        }
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/smart/CustomTexted.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/smart/CustomTexted.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.list.smart;
+
+import android.support.annotation.IdRes;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.schedjoules.eventdiscovery.framework.list.ListItem;
+
+
+/**
+ * {@link ListItem} decorator that can set up custom text for a {@link TextView} child of the {@link View} corresponding to the delegate {@link ListItem}.
+ * <p>
+ * Note: {@link Button} is a {@link TextView} as well.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class CustomTexted<V extends View> implements ListItem<V>
+{
+
+    private final ListItem<V> mDelegate;
+    private final int mTextViewId;
+    private final CharSequence mCustomText;
+
+
+    public CustomTexted(ListItem<V> delegate, @IdRes int textViewId, CharSequence customText)
+    {
+        mDelegate = delegate;
+        mTextViewId = textViewId;
+        mCustomText = customText;
+    }
+
+
+    @Override
+    public int layoutResId()
+    {
+        return mDelegate.layoutResId();
+    }
+
+
+    @Override
+    public void bindDataTo(V view)
+    {
+        mDelegate.bindDataTo(view);
+        ((TextView) view.findViewById(mTextViewId)).setText(mCustomText);
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/smart/SubClickable.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/list/smart/SubClickable.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.list.smart;
+
+import android.support.annotation.IdRes;
+import android.view.View;
+
+import com.schedjoules.eventdiscovery.framework.list.ListItem;
+import com.schedjoules.eventdiscovery.framework.utils.smartview.OnClickAction;
+
+
+/**
+ * {@link ListItem} decorator that can set up a {@link OnClickAction} linked to specific child view of the related View.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class SubClickable<V extends View> implements ListItem<V>
+{
+
+    private final ListItem<V> mDelegate;
+    private final int mChildViewId;
+    private final OnClickAction mOnClickAction;
+
+
+    public SubClickable(ListItem<V> delegate, @IdRes int childViewId, OnClickAction onClickAction)
+    {
+        mDelegate = delegate;
+        mChildViewId = childViewId;
+        mOnClickAction = onClickAction;
+    }
+
+
+    @Override
+    public int layoutResId()
+    {
+        return mDelegate.layoutResId();
+    }
+
+
+    @Override
+    public void bindDataTo(V view)
+    {
+        mDelegate.bindDataTo(view);
+        view.findViewById(mChildViewId).setOnClickListener(new View.OnClickListener()
+        {
+            @Override
+            public void onClick(View v)
+            {
+                mOnClickAction.onClick();
+            }
+        });
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/CurrentLocationModuleFactory.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/CurrentLocationModuleFactory.java
@@ -15,47 +15,45 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.recentlocations;
+package com.schedjoules.eventdiscovery.framework.location;
 
 import android.app.Activity;
-import android.content.Context;
 
+import com.schedjoules.eventdiscovery.framework.googleapis.GoogleApis;
 import com.schedjoules.eventdiscovery.framework.list.ItemChosenAction;
 import com.schedjoules.eventdiscovery.framework.list.ListItem;
 import com.schedjoules.eventdiscovery.framework.location.model.GeoPlace;
 import com.schedjoules.eventdiscovery.framework.searchlist.SearchModule;
 import com.schedjoules.eventdiscovery.framework.searchlist.SearchModuleFactory;
 import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.ResultUpdateListener;
+import com.schedjoules.eventdiscovery.framework.utils.factory.ThreadSafeLazy;
 
 
 /**
- * A decorator to {@link SearchModuleFactory}s of {@link GeoPlace}s that adds the selected {@link GeoPlace} to the recent locations.
+ * {@link SearchModuleFactory} for {@link CurrentLocationModule}.
  *
- * @author Marten Gajda
+ * @author Gabor Keszthelyi
  */
-public final class Remembered implements SearchModuleFactory<GeoPlace>
+public final class CurrentLocationModuleFactory implements SearchModuleFactory<GeoPlace>
 {
-    private final SearchModuleFactory<GeoPlace> mDelegate;
+    private final GoogleApis mGoogleApis;
 
 
-    public Remembered(SearchModuleFactory<GeoPlace> delegate)
+    public CurrentLocationModuleFactory(GoogleApis googleApis)
     {
-        mDelegate = delegate;
+        mGoogleApis = googleApis;
     }
 
 
     @Override
-    public SearchModule create(final Activity activity, ResultUpdateListener<ListItem> updateListener, final ItemChosenAction<GeoPlace> itemSelectionAction)
+    public SearchModule create(final Activity activity, ResultUpdateListener<ListItem> updateListener, ItemChosenAction<GeoPlace> itemChosenAction)
     {
-        final Context context = activity.getApplicationContext();
-        return mDelegate.create(activity, updateListener, new ItemChosenAction<GeoPlace>()
-        {
-            @Override
-            public void onItemChosen(GeoPlace itemData)
-            {
-                new RecentGeoPlaces(context).recent(itemData).remember();
-                itemSelectionAction.onItemChosen(itemData);
-            }
-        });
+        return new CurrentLocationModule(
+                activity,
+                updateListener,
+                itemChosenAction,
+                new ThreadSafeLazy<>(new GeocoderFactory(activity)),
+                mGoogleApis);
     }
+
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/GeocoderFactory.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/GeocoderFactory.java
@@ -15,30 +15,35 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
+package com.schedjoules.eventdiscovery.framework.location;
 
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
+import android.app.Activity;
+import android.location.Geocoder;
+
+import com.schedjoules.eventdiscovery.framework.utils.factory.Factory;
+
+import java.util.Locale;
 
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * Factory for {@link Geocoder}.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public final class GeocoderFactory implements Factory<Geocoder>
 {
+    private final Activity mActivity;
 
-    public MessageItem(CharSequence text)
+
+    public GeocoderFactory(Activity activity)
     {
-        super(text, R.layout.schedjoules_list_item_location_message);
+        mActivity = activity;
     }
 
 
     @Override
-    protected String toStringLabel()
+    public Geocoder create()
     {
-        return "MessageItem";
+        return new Geocoder(mActivity, Locale.getDefault());
     }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/PlaceSuggestionModuleFactory.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/PlaceSuggestionModuleFactory.java
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.recentlocations;
+package com.schedjoules.eventdiscovery.framework.location;
 
 import android.app.Activity;
-import android.content.Context;
 
+import com.schedjoules.eventdiscovery.framework.googleapis.GoogleApis;
 import com.schedjoules.eventdiscovery.framework.list.ItemChosenAction;
 import com.schedjoules.eventdiscovery.framework.list.ListItem;
 import com.schedjoules.eventdiscovery.framework.location.model.GeoPlace;
@@ -29,33 +29,25 @@ import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.ResultU
 
 
 /**
- * A decorator to {@link SearchModuleFactory}s of {@link GeoPlace}s that adds the selected {@link GeoPlace} to the recent locations.
+ * {@link SearchModuleFactory} for {@link PlaceSuggestionModule}.
  *
- * @author Marten Gajda
+ * @author Gabor Keszthelyi
  */
-public final class Remembered implements SearchModuleFactory<GeoPlace>
+public final class PlaceSuggestionModuleFactory implements SearchModuleFactory<GeoPlace>
 {
-    private final SearchModuleFactory<GeoPlace> mDelegate;
+    private final GoogleApis mGoogleApis;
 
 
-    public Remembered(SearchModuleFactory<GeoPlace> delegate)
+    public PlaceSuggestionModuleFactory(GoogleApis googleApis)
     {
-        mDelegate = delegate;
+        mGoogleApis = googleApis;
     }
 
 
     @Override
-    public SearchModule create(final Activity activity, ResultUpdateListener<ListItem> updateListener, final ItemChosenAction<GeoPlace> itemSelectionAction)
+    public SearchModule create(Activity activity, ResultUpdateListener<ListItem> updateListener, ItemChosenAction<GeoPlace> itemChosenAction)
     {
-        final Context context = activity.getApplicationContext();
-        return mDelegate.create(activity, updateListener, new ItemChosenAction<GeoPlace>()
-        {
-            @Override
-            public void onItemChosen(GeoPlace itemData)
-            {
-                new RecentGeoPlaces(context).recent(itemData).remember();
-                itemSelectionAction.onItemChosen(itemData);
-            }
-        });
+        return new PlaceSuggestionModule(activity, updateListener, itemChosenAction, mGoogleApis);
     }
+
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/listitems/ButtonedMessageItem.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/listitems/ButtonedMessageItem.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.location.listitems;
+
+import android.view.View;
+import android.widget.Button;
+
+import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.list.ListItem;
+import com.schedjoules.eventdiscovery.framework.utils.smartview.OnClickAction;
+
+
+/**
+ * A {@link ListItem} on the location picker that displays a message and a button.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class ButtonedMessageItem implements ListItem<ButtonedMessageItemView>
+{
+
+    private final CharSequence mMessageText;
+    private final CharSequence mButtonText;
+    private final OnClickAction mButtonClickAction;
+
+
+    public ButtonedMessageItem(CharSequence messageText, CharSequence buttonText, OnClickAction buttonClickAction)
+    {
+        mMessageText = messageText;
+        mButtonText = buttonText;
+        mButtonClickAction = buttonClickAction;
+    }
+
+
+    @Override
+    public int layoutResId()
+    {
+        return R.layout.schedjoules_list_item_location_buttoned_message;
+    }
+
+
+    @Override
+    public void bindDataTo(ButtonedMessageItemView view)
+    {
+        view.update(mMessageText);
+
+        Button button = (Button) view.findViewById(ButtonedMessageItemView.ID_BUTTON);
+        button.setText(mButtonText);
+        button.setOnClickListener(new View.OnClickListener()
+        {
+            @Override
+            public void onClick(View v)
+            {
+                mButtonClickAction.onClick();
+            }
+        });
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/listitems/ButtonedMessageItemView.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/listitems/ButtonedMessageItemView.java
@@ -28,22 +28,24 @@ import com.schedjoules.eventdiscovery.framework.utils.smartview.SmartView;
 
 
 /**
- * A {@link View} for a location picker list item that shows a message.
+ * A {@link View} for a location picker list item that shows a message and a button.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItemView extends RelativeLayout implements SmartView<CharSequence>
+public final class ButtonedMessageItemView extends RelativeLayout implements SmartView<CharSequence>
 {
+    public static int ID_BUTTON = R.id.schedjoules_place_message_item_button;
+
     private TextView mTextView;
 
 
-    public MessageItemView(Context context)
+    public ButtonedMessageItemView(Context context)
     {
         super(context);
     }
 
 
-    public MessageItemView(Context context, AttributeSet attrs)
+    public ButtonedMessageItemView(Context context, AttributeSet attrs)
     {
         super(context, attrs);
     }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/namedplace/CommaSeparated.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/model/namedplace/CommaSeparated.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.location.model.namedplace;
+
+/**
+ * Comma separated text from {@link NamedPlace}, like "Amsterdam, Netherlands".
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class CommaSeparated implements CharSequence
+{
+    private final NamedPlace mNamedPlace;
+
+    private String mToString;
+
+
+    public CommaSeparated(NamedPlace namedPlace)
+    {
+        mNamedPlace = namedPlace;
+    }
+
+
+    @Override
+    public int length()
+    {
+        return toString().length();
+    }
+
+
+    @Override
+    public char charAt(int index)
+    {
+        return toString().charAt(index);
+    }
+
+
+    @Override
+    public CharSequence subSequence(int start, int end)
+    {
+        return toString().subSequence(start, end);
+    }
+
+
+    @Override
+    public String toString()
+    {
+        if (mToString == null)
+        {
+            mToString = mNamedPlace.name() + ", " + mNamedPlace.extraContext();
+        }
+        return mToString;
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/recentlocations/RecentGeoPlaces.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/location/recentlocations/RecentGeoPlaces.java
@@ -33,7 +33,7 @@ import java.util.Iterator;
  *
  * @author Marten Gajda
  */
-public class RecentGeoPlaces implements Recents<GeoPlace>
+public final class RecentGeoPlaces implements Recents<GeoPlace>
 {
     private final Recents<GeoPlace> mDelegate;
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/QueryPredicate.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/QueryPredicate.java
@@ -15,30 +15,18 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
-
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
-
+package com.schedjoules.eventdiscovery.framework.searchlist;
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * A general predicate for checking whether a query is valid in a certain context or not.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public interface QueryPredicate
 {
 
-    public MessageItem(CharSequence text)
-    {
-        super(text, R.layout.schedjoules_list_item_location_message);
-    }
-
-
-    @Override
-    protected String toStringLabel()
-    {
-        return "MessageItem";
-    }
+    /**
+     * Tells whether the given query is valid in the given context or not.
+     */
+    boolean isValid(String query);
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/SearchModulesFactory.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/SearchModulesFactory.java
@@ -17,7 +17,7 @@
 
 package com.schedjoules.eventdiscovery.framework.searchlist;
 
-import android.app.Activity;
+import android.support.v4.app.FragmentActivity;
 
 import com.schedjoules.eventdiscovery.framework.list.ItemChosenAction;
 import com.schedjoules.eventdiscovery.framework.searchlist.resultupdates.SectionedResultUpdateListenerAdapter;
@@ -34,13 +34,13 @@ import java.util.List;
  */
 public final class SearchModulesFactory<ITEM_DATA> implements Factory<List<SearchModule>>
 {
-    private final Activity mActivity;
+    private final FragmentActivity mActivity;
     private final SearchListItems mSearchListItems;
     private final ItemChosenAction<ITEM_DATA> mItemChosenAction;
     private final List<SearchModuleFactory<ITEM_DATA>> mFactories;
 
 
-    public SearchModulesFactory(Activity activity,
+    public SearchModulesFactory(FragmentActivity activity,
                                 SearchListItems searchListItems,
                                 ItemChosenAction<ITEM_DATA> itemChosenAction,
                                 List<SearchModuleFactory<ITEM_DATA>> factories)

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/delaying/DelayingUpdateListener.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/delaying/DelayingUpdateListener.java
@@ -84,7 +84,7 @@ public final class DelayingUpdateListener implements SectionedResultUpdateListen
     }
 
 
-    private class SingleUpdate implements Runnable
+    private final class SingleUpdate implements Runnable
     {
         private final int mSectionNumber;
         private final ResultUpdate<ListItem> mSectionUpdate;
@@ -105,7 +105,7 @@ public final class DelayingUpdateListener implements SectionedResultUpdateListen
     }
 
 
-    private class RunAllUpdates implements Runnable
+    private final class RunAllUpdates implements Runnable
     {
 
         @Override

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/permissionproxy/PermissionProxy.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/permissionproxy/PermissionProxy.java
@@ -142,7 +142,7 @@ public final class PermissionProxy implements SearchModule
     }
 
 
-    private class PermissionRequestOnClick implements OnClickAction
+    private final class PermissionRequestOnClick implements OnClickAction
     {
         @Override
         public void onClick()

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/ForcedClear.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/ForcedClear.java
@@ -15,30 +15,23 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
+package com.schedjoules.eventdiscovery.framework.searchlist.resultupdates;
 
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
+import com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.ClearAll;
+import com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.NonNotifyingChangeableList;
 
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * {@link ResultUpdate} to clear all items regardless of the current query.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public final class ForcedClear<T> implements ResultUpdate<T>
 {
 
-    public MessageItem(CharSequence text)
-    {
-        super(text, R.layout.schedjoules_list_item_location_message);
-    }
-
-
     @Override
-    protected String toStringLabel()
+    public void apply(NonNotifyingChangeableList<T> changeableList, String currentQuery)
     {
-        return "MessageItem";
+        changeableList.apply(new ClearAll<T>());
     }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/ForcedShowSingle.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/searchlist/resultupdates/ForcedShowSingle.java
@@ -15,30 +15,31 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
+package com.schedjoules.eventdiscovery.framework.searchlist.resultupdates;
 
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
+import com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.NonNotifyingChangeableList;
+import com.schedjoules.eventdiscovery.framework.list.changes.nonnotifying.ReplaceAll;
 
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * {@link ResultUpdate} to show the given item regardless of the current query string.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public final class ForcedShowSingle<T> implements ResultUpdate<T>
 {
+    private final T mItem;
 
-    public MessageItem(CharSequence text)
+
+    public ForcedShowSingle(T item)
     {
-        super(text, R.layout.schedjoules_list_item_location_message);
+        mItem = item;
     }
 
 
     @Override
-    protected String toStringLabel()
+    public void apply(NonNotifyingChangeableList<T> changeableList, String currentQuery)
     {
-        return "MessageItem";
+        changeableList.apply(new ReplaceAll<T>(mItem));
     }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/ActivityReloadAction.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/ActivityReloadAction.java
@@ -15,30 +15,33 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
+package com.schedjoules.eventdiscovery.framework.utils;
 
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
+import android.app.Activity;
+
+import com.schedjoules.eventdiscovery.framework.utils.smartview.OnClickAction;
 
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * {@link OnClickAction} that reloads the given Activity.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public final class ActivityReloadAction implements OnClickAction
 {
+    private final Activity mActivity;
 
-    public MessageItem(CharSequence text)
+
+    public ActivityReloadAction(Activity activity)
     {
-        super(text, R.layout.schedjoules_list_item_location_message);
+        mActivity = activity;
     }
 
 
     @Override
-    protected String toStringLabel()
+    public void onClick()
     {
-        return "MessageItem";
+        mActivity.finish();
+        mActivity.startActivity(mActivity.getIntent());
     }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/Listenable.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/Listenable.java
@@ -15,30 +15,17 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
-
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
-
+package com.schedjoules.eventdiscovery.framework.utils;
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * General interface for components that are 'listenable', i.e. can notify registered listeners of the given type.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public interface Listenable<L>
 {
-
-    public MessageItem(CharSequence text)
-    {
-        super(text, R.layout.schedjoules_list_item_location_message);
-    }
-
-
-    @Override
-    protected String toStringLabel()
-    {
-        return "MessageItem";
-    }
+    /**
+     * Registers the given listener to be notified when the corresponding event/callback happens.
+     */
+    void listen(L listener);
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/factory/Lazy.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/factory/Lazy.java
@@ -15,30 +15,17 @@
  * limitations under the License.
  */
 
-package com.schedjoules.eventdiscovery.framework.location.listitems;
-
-import com.schedjoules.eventdiscovery.R;
-import com.schedjoules.eventdiscovery.framework.list.ListItem;
-import com.schedjoules.eventdiscovery.framework.list.smart.AbstractSmartListItem;
-
+package com.schedjoules.eventdiscovery.framework.utils.factory;
 
 /**
- * A {@link ListItem} on the location picker that displays a message.
+ * Represents a lazily created instance of type <code>T</code>.
  *
  * @author Gabor Keszthelyi
  */
-public final class MessageItem extends AbstractSmartListItem<CharSequence, MessageItemView>
+public interface Lazy<T>
 {
-
-    public MessageItem(CharSequence text)
-    {
-        super(text, R.layout.schedjoules_list_item_location_message);
-    }
-
-
-    @Override
-    protected String toStringLabel()
-    {
-        return "MessageItem";
-    }
+    /**
+     * Returns the instance which is created on first access.
+     */
+    T get();
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/factory/ThreadSafeLazy.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/factory/ThreadSafeLazy.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.factory;
+
+/**
+ * Thread-safe implementation for {@link Lazy} using a provided {@link Factory}.
+ * <p>
+ * See <a href="https://en.wikipedia.org/wiki/Double-checked_locking">Double-checked locking</a>.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class ThreadSafeLazy<T> implements Lazy<T>
+{
+    private final Factory<T> mFactory;
+
+    private Wrapper<T> mWrapper;
+
+
+    public ThreadSafeLazy(Factory<T> factory)
+    {
+        mFactory = factory;
+    }
+
+
+    @Override
+    public T get()
+    {
+        Wrapper<T> tempWrapper = mWrapper;
+
+        if (tempWrapper == null)
+        {
+            synchronized (this)
+            {
+                if (mWrapper == null)
+                {
+                    mWrapper = new Wrapper<T>(mFactory.create());
+                }
+                tempWrapper = mWrapper;
+            }
+        }
+        return tempWrapper.mValue;
+    }
+
+
+    private static class Wrapper<T>
+    {
+        private final T mValue;
+
+
+        private Wrapper(T value)
+        {
+            mValue = value;
+        }
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_list_item_location_buttoned_message.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_list_item_location_buttoned_message.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.schedjoules.eventdiscovery.framework.location.listitems.PlaceSuggestionItemView
+<com.schedjoules.eventdiscovery.framework.location.listitems.ButtonedMessageItemView
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -8,25 +8,24 @@
         android:background="?attr/selectableItemBackground">
 
     <TextView
-            android:id="@+id/schedjoules_place_suggestion_item_name"
+            android:id="@+id/schedjoules_place_message_item_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
             android:layout_marginLeft="@dimen/schedjoules_location_list_item_horizontal_margin"
             android:layout_marginRight="@dimen/schedjoules_location_list_item_horizontal_margin"
-            android:layout_marginTop="10dp"
-            android:layout_marginBottom="1dp"
             android:textSize="16sp"/>
 
-    <TextView
-            android:id="@+id/schedjoules_location_suggestion_item_extra_context"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@id/schedjoules_place_suggestion_item_name"
+    <Button
+            android:id="@+id/schedjoules_place_message_item_button"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:textColor="@color/schedjoules_colorAccent"
+            android:layout_below="@id/schedjoules_place_message_item_title"
             android:layout_marginLeft="@dimen/schedjoules_location_list_item_horizontal_margin"
             android:layout_marginRight="@dimen/schedjoules_location_list_item_horizontal_margin"
-            android:layout_marginTop="1dp"
-            android:layout_marginBottom="10dp"
-            android:textSize="12sp"/>
+            android:layout_alignParentRight="true"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
 
     <View
             android:layout_height="1px"
@@ -34,4 +33,4 @@
             android:background="@color/schedjoules_divider"
             android:layout_alignParentBottom="true"/>
 
-</com.schedjoules.eventdiscovery.framework.location.listitems.PlaceSuggestionItemView>
+</com.schedjoules.eventdiscovery.framework.location.listitems.ButtonedMessageItemView>

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_list_item_location_message.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_list_item_location_message.xml
@@ -11,12 +11,11 @@
             android:id="@+id/schedjoules_place_message_item_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="12dp"
-            android:paddingBottom="12dp"
-            android:paddingLeft="24dp"
-            android:paddingRight="24dp"
+            android:layout_marginTop="12dp"
+            android:layout_marginBottom="12dp"
+            android:layout_marginLeft="@dimen/schedjoules_location_list_item_horizontal_margin"
+            android:layout_marginRight="@dimen/schedjoules_location_list_item_horizontal_margin"
             android:textSize="16sp"
-            android:gravity="left|center_vertical"
             android:layout_centerVertical="true"/>
 
     <View

--- a/eventdiscovery-sdk/src/main/res/values/dimens.xml
+++ b/eventdiscovery-sdk/src/main/res/values/dimens.xml
@@ -17,6 +17,7 @@
     <dimen name="schedjoules_event_details_ticket_button_area_height">72dp</dimen>
 
     <dimen name="schedjoules_location_list_item_height">64dp</dimen>
+    <dimen name="schedjoules_location_list_item_horizontal_margin">24dp</dimen>
 
     <dimen name="schedjoules_toolbar_title_font_size">20dp</dimen>
 </resources>

--- a/eventdiscovery-sdk/src/main/res/values/strings.xml
+++ b/eventdiscovery-sdk/src/main/res/values/strings.xml
@@ -52,11 +52,21 @@
     <!-- List message item displayed in place of current location after user denied to give permission to access their location on the system dialog and also checked "Never show again" checkbox. (They can only give the permission from phone settings after that.)-->
     <string name="schedjoules_location_picker_current_location_permission_inform_about_phone_settings">To later enable current location display, allow access to your location from your device settings.</string>
     <!-- Error message list item displayed in place of current location when there was some error during retrieving the location. -->
-    <string name="schedjoules_location_picker_current_location_error">We could not determine your location. Please tap to retry.</string>
+    <string name="schedjoules_location_picker_current_location_error">We could not determine your location.</string>
     <!-- The title above the list items for place suggestions, i.e. suggestions retrieved from Google based on the text the user types.-->
     <string name="schedjoules_location_picker_caption_place_suggestions">Suggestions</string>
     <!-- The title above the list of recently selected location. -->
     <string name="schedjoules_location_picker_caption_recent_locations">Recent locations</string>
+    <!-- Error message item when Google API location service cannot be used for some reason, but user can retry. -->
+    <string name="schedjoules_location_picker_googleapi_error_recovarable">Could not access Google location service</string>
+    <!-- Error message item when Google API location service cannot be used for some reason, and it cannot be resolved (no retry button). -->
+    <string name="schedjoules_location_picker_googleapi_error_unrecovarable">Google location services are not available, location search doesn\'t work.</string>
+    <!-- Error message item when location suggestion request fails for some reason. -->
+    <string name="schedjoules_location_picker_suggestion_error">Could not get suggestions</string>
+    <!-- Error message itemm when user selects a location from the query suggestions, but request fails to download the extra information needed. -->
+    <string name="schedjoules_location_picker_suggestion_placelookup_error">Could not get data for\n\'%s\'</string>
+    <!-- General "Retry" button label -->
+    <string name="schedjoules_retry">Retry</string>
 
     <!-- A brief message that's presented to the user if there is no (official) API coverage for his country. -->
     <string name="schedjoules_message_country_not_supported">Event discovery is currently not supported in your country.</string>

--- a/eventdiscovery-sdk/src/test/java/com/schedjoules/eventdiscovery/framework/list/sectioned/ListSectionChangeTest.java
+++ b/eventdiscovery-sdk/src/test/java/com/schedjoules/eventdiscovery/framework/list/sectioned/ListSectionChangeTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ RecyclerView.Adapter.class })
-public class ListSectionChangeTest
+public final class ListSectionChangeTest
 {
 
     private RecyclerView.Adapter mAdapter;

--- a/eventdiscovery-sdk/src/test/java/com/schedjoules/eventdiscovery/framework/list/sectioned/TestListItem.java
+++ b/eventdiscovery-sdk/src/test/java/com/schedjoules/eventdiscovery/framework/list/sectioned/TestListItem.java
@@ -27,7 +27,7 @@ import com.schedjoules.eventdiscovery.framework.list.ListItem;
  *
  * @author Gabor Keszthelyi
  */
-public class TestListItem implements ListItem
+public final class TestListItem implements ListItem
 {
     private final int mId;
 

--- a/eventdiscovery-sdk/src/test/java/com/schedjoules/eventdiscovery/framework/model/recent/places/GeoPlaceCharSequenceConverterTest.java
+++ b/eventdiscovery-sdk/src/test/java/com/schedjoules/eventdiscovery/framework/model/recent/places/GeoPlaceCharSequenceConverterTest.java
@@ -31,7 +31,7 @@ import static junit.framework.Assert.assertEquals;
 /**
  * @author Marten Gajda
  */
-public class GeoPlaceCharSequenceConverterTest
+public final class GeoPlaceCharSequenceConverterTest
 {
     @Test
     public void fromValue() throws Exception


### PR DESCRIPTION
PR for #134 

This is based on current location branch (95), so after that is merged, this can be rebased to master.

@dmfs Please review

Known issues:
- The Google error message disappears upon rotation
- The Google error message for the current location doesn’t reappear after typing and clearing it back

I suggest creating a low priority bug to the backlog about these.

A specific note:
There are 2 new classes that at lastest state are not used: `SubClickable`: allows to decorate `ListItem` with action for a child view id. `CustomTexted`: allows to decorate `ListItem` to customize a text of a child TextView id. I used them for `ButtonedMessageItem` at a point, but it looked better eventually if this `ListItem` actually gets its required input in the constructor. But I would still keep those 2 decorators, they can come useful later.