### PR TITLE
PR for 174: Fix zombie GoogleApiClients

### DIFF
--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/requests/ConnectionErrorHandling.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/googleapis/requests/ConnectionErrorHandling.java
@@ -17,6 +17,8 @@
 
 package com.schedjoules.eventdiscovery.framework.googleapis.requests;
 
+import android.util.Log;
+
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.Api;
 import com.google.android.gms.common.api.GoogleApiClient;
@@ -37,6 +39,8 @@ import java.util.concurrent.TimeUnit;
  */
 public final class ConnectionErrorHandling<T> implements GoogleApiRequest<T>
 {
+    private static final String TAG = "ConnectionErrorHandling";
+
     private final GoogleApiRequest<T> mDelegate;
 
 
@@ -49,9 +53,10 @@ public final class ConnectionErrorHandling<T> implements GoogleApiRequest<T>
     @Override
     public final T execute(GoogleApiClient googleApiClient) throws AbstractGoogleApiRequestException
     {
-        ConnectionResult connectionResult = googleApiClient.blockingConnect(3, TimeUnit.SECONDS);
+        ConnectionResult connectionResult = googleApiClient.blockingConnect(2, TimeUnit.SECONDS);
         if (!connectionResult.isSuccess())
         {
+            Log.e(TAG, "Error ConnectionResult: " + connectionResult);
             if (connectionResult.hasResolution())
             {
                 // This is being auto-managed

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/factory/PeekableLazy.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/factory/PeekableLazy.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.factory;
+
+/**
+ * {@link Lazy} that can tell whether it has been initialized already or not.
+ *
+ * @author Gabor Keszthelyi
+ */
+public interface PeekableLazy<T> extends Lazy<T>
+{
+    /**
+     * Tells whether the underlying instance has been created already or not.
+     */
+    boolean isCreated();
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/factory/ThreadSafeLazy.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/factory/ThreadSafeLazy.java
@@ -24,7 +24,7 @@ package com.schedjoules.eventdiscovery.framework.utils.factory;
  *
  * @author Gabor Keszthelyi
  */
-public final class ThreadSafeLazy<T> implements Lazy<T>
+public final class ThreadSafeLazy<T> implements PeekableLazy<T>
 {
     private final Factory<T> mFactory;
 
@@ -54,6 +54,13 @@ public final class ThreadSafeLazy<T> implements Lazy<T>
             }
         }
         return tempWrapper.mValue;
+    }
+
+
+    @Override
+    public synchronized boolean isCreated()
+    {
+        return mWrapper != null && mWrapper.mValue != null;
     }
 
 


### PR DESCRIPTION
Small changes for GoogleApis related code.

Ready for review,
@dmfs Could you please maybe test on real device that this line of code is actually executed when there is a resolvable Play Services related error?:

```
com/schedjoules/eventdiscovery/framework/googleapis/requests/ConnectionErrorHandling.java:60

if (connectionResult.hasResolution())
{
     // This is being auto-managed
     throw new GoogleApiAutoManagedIssueException(connectionResult.toString());
}
```
On the emulator I have, `hasResulution()` is always `false` even if it shows a dialog to update Play Services. It may be because eventually it can't be updated, when I press the button, nothing happens. It might different on real device.

Regarding the removed synchnorization for the `Set` in `BasicGoogleApis`, I know it means an `Api` could be readded and the client rebuild in a rare case, but I think that's okay, doesn't cause error, so I trade that with having to lock on the `Set` for every call.
But the main point of the change in the class there is to `disconnect()` the old `GoogleApiClient`.