### PR TITLE
PR for 166: Fix Current Location 'fllickering'

### DIFF
--- a/eventdiscovery-sdk/src/main/res/values-de/strings.xml
+++ b/eventdiscovery-sdk/src/main/res/values-de/strings.xml
@@ -49,7 +49,6 @@
     <string name="schedjoules_tomorrow">Morgen</string>
 
     <string name="schedjoules_location_picker_current_location">Mein Standort</string>
-    <string name="schedjoules_location_picker_current_location_locating">Standort wird ermittelt…</string>
     <string name="schedjoules_location_picker_current_location_permission_rationale">Bitte erlaube den Zugriff auf deinen Standort um diese Funkionen nutzen zu können.</string>
     <string name="schedjoules_location_picker_current_location_permission_inform_about_phone_settings">Bitte erteile die Standort Berechtigung in den Systemeinstellungen um diese Funktion später nutzen zu können.</string>
     <string name="schedjoules_location_picker_current_location_error">Dein Standort konnte nicht ermittelt werden. Hier tippen um es erneut zu versuchen.</string>

--- a/eventdiscovery-sdk/src/main/res/values-nl/strings.xml
+++ b/eventdiscovery-sdk/src/main/res/values-nl/strings.xml
@@ -33,7 +33,6 @@
     <string name="schedjoules_tomorrow">Morgen</string>
 
     <string name="schedjoules_location_picker_current_location">Huidige locatie</string>
-    <string name="schedjoules_location_picker_current_location_locating">Locatie zoeken…</string>
     <string name="schedjoules_location_picker_current_location_permission_rationale">Om uw huidige locatie te kunnen gebruiken, geeft u toegang tot uw locatie.</string>
     <string name="schedjoules_location_picker_current_location_permission_inform_about_phone_settings">Om weergave van uw huidige locatie later mogelijk te maken, geeft u toegang tot uw locatie in de instellingen van uw toestel.</string>
     <string name="schedjoules_location_picker_current_location_error">Het is niet gelukt om uw locatie te bepalen. Klik om het opnieuw te proberen.</string>

--- a/eventdiscovery-sdk/src/main/res/values/strings.xml
+++ b/eventdiscovery-sdk/src/main/res/values/strings.xml
@@ -45,8 +45,6 @@
 
     <!-- Location picker list item name for current location of the user/device -->
     <string name="schedjoules_location_picker_current_location">Current location</string>
-    <!-- Progress list item displayed during retrieving the current location -->
-    <string name="schedjoules_location_picker_current_location_locating">Find location…</string>
     <!-- List message item displayed in place of current location after user denied to give permission to access their location on the system dialog. -->
     <string name="schedjoules_location_picker_current_location_permission_rationale">To use your current location, please allow access to your location.</string>
     <!-- List message item displayed in place of current location after user denied to give permission to access their location on the system dialog and also checked "Never show again" checkbox. (They can only give the permission from phone settings after that.)-->


### PR DESCRIPTION
The solution applied is to simply fire a caching call for current location once the screen loads. When user taps the call is done again, but it will likely be served quickly from the cache.
The "Find location.." progress item has been removed.

In case the call would take long and the user would press "Current location" quickly, before the caching call finishes, there can be some time between user tapping and screen disappearing, there is no progress indicator for that now. If that's important at this point, that could be a separate ticket I think. I have some idea about `ListItem` updates for that.