### PR TITLE
PR for 207: Fix map fragment crash by adding it from code instead of xml

### DIFF
--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/views/EventDetailsView.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/views/EventDetailsView.java
@@ -90,7 +90,12 @@ public final class EventDetailsView implements SmartView<ShowEventMicroFragment.
 
         new TicketButtonView(mViews).update(new TicketButtonAction(actionLinks, event));
 
-        final SupportMapFragment mapFragment = (SupportMapFragment) mFragment.getChildFragmentManager().findFragmentById(R.id.schedjoules_event_details_map);
+        SupportMapFragment mapFragment = SupportMapFragment.newInstance();
+        mFragment.getChildFragmentManager()
+                .beginTransaction()
+                .add(R.id.schedjoules_event_details_map_frame, mapFragment)
+                .commit();
+
         mapFragment.getMapAsync(new OnMapReadyCallback()
         {
             @Override
@@ -99,7 +104,7 @@ public final class EventDetailsView implements SmartView<ShowEventMicroFragment.
                 GeoLocation geoLocation = event.locations().iterator().next().geoLocation();
                 LatLng latLng = new LatLng(geoLocation.latitude(), geoLocation.longitude());
                 googleMap.addMarker(new MarkerOptions().position(latLng));
-                googleMap.moveCamera(CameraUpdateFactory.newLatLng(latLng));
+                googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(latLng, 15));
             }
         });
         mViews.schedjoulesEventDetailsMapHolder.schedjoulesEventDetailsMapTransparentOverlay

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_view_event_details_map.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_view_event_details_map.xml
@@ -7,14 +7,10 @@
             android:layout_height="200dp"
             android:layout_marginTop="8dp">
 
-        <fragment
-                xmlns:map="http://schemas.android.com/apk/res-auto"
-                android:id="@+id/schedjoules_event_details_map"
+        <FrameLayout
+                android:id="@+id/schedjoules_event_details_map_frame"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                map:cameraZoom="15"
-                map:mapType="normal"
-                android:name="com.google.android.gms.maps.SupportMapFragment"/>
+                android:layout_height="match_parent"/>
 
         <ImageView
                 android:id="@+id/schedjoules_event_details_map_transparent_overlay"


### PR DESCRIPTION
@dmfs I looked up [MapView docs](https://developers.google.com/android/reference/com/google/android/gms/maps/MapView) and saw this instruction:
_"Users of this class must forward all the life cycle methods from the Activity or Fragment.."_
So it looks cumbersome to use `MapView` directly.

On the other hand, in the SO post you posted, they say the crash is general for fragments defined in xml, but doesn't happen when added from code: http://stackoverflow.com/a/31755655

So I fixed it by just adding the `SupportMapFragment` from code to a `FrameLayout` holder.