### PR TITLE
PR for 209: Fix AppBar casting shadow on StatusBar

### DIFF
--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/common/StatusBar.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/common/StatusBar.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.common;
+
+import android.app.Activity;
+import android.os.Build;
+import android.view.Window;
+import android.view.WindowManager;
+
+import com.schedjoules.eventdiscovery.framework.utils.Color;
+import com.schedjoules.eventdiscovery.framework.utils.smartview.SmartView;
+
+
+/**
+ * Represents the status bar with updatable color.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class StatusBar implements SmartView<Color>
+{
+    private final Activity mActivity;
+
+
+    public StatusBar(Activity activity)
+    {
+        mActivity = activity;
+    }
+
+
+    @Override
+    public void update(Color color)
+    {
+        // http://stackoverflow.com/a/26749343/4247460
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+        {
+            Window window = mActivity.getWindow();
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+            window.setStatusBarColor(color.argb());
+        }
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/views/EventHeaderView.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/views/EventHeaderView.java
@@ -26,8 +26,10 @@ import com.bumptech.glide.Glide;
 import com.schedjoules.client.eventsdiscovery.Event;
 import com.schedjoules.eventdiscovery.R;
 import com.schedjoules.eventdiscovery.databinding.SchedjoulesDetailsHeaderBinding;
+import com.schedjoules.eventdiscovery.framework.common.StatusBar;
 import com.schedjoules.eventdiscovery.framework.utils.AttributeColor;
 import com.schedjoules.eventdiscovery.framework.utils.SchedJoulesLinks;
+import com.schedjoules.eventdiscovery.framework.utils.Transparent;
 import com.schedjoules.eventdiscovery.framework.utils.smartview.SmartView;
 
 
@@ -54,6 +56,8 @@ public final class EventHeaderView implements SmartView<Event>
     @Override
     public void update(Event event)
     {
+        new StatusBar(mActivity).update(Transparent.INSTANCE);
+
         Glide.with(mActivity)
                 .load(new SchedJoulesLinks(event.links()).bannerUri())
                 .into(mHeader.schedjoulesEventDetailBanner);

--- a/eventdiscovery-sdk/src/main/res/values-v21/theme_dark.xml
+++ b/eventdiscovery-sdk/src/main/res/values-v21/theme_dark.xml
@@ -5,7 +5,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">?attr/colorPrimaryDark</item>
     </style>
 
 </resources>

--- a/eventdiscovery-sdk/src/main/res/values-v21/theme_light.xml
+++ b/eventdiscovery-sdk/src/main/res/values-v21/theme_light.xml
@@ -5,7 +5,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">?attr/colorPrimaryDark</item>
     </style>
 
 </resources>


### PR DESCRIPTION
> The reason is probably the transparent background color of the status bar. Activities (or "root-fragments") that don't use a collapsingtoolbarlayout should probably set the status bar background to a solid primaryColorDark

Yes, that seemed to be the cause, AppBar probably casts shadow on the status bar. I've found the issue asked here:
http://stackoverflow.com/questions/34891756/toolbars-shadow-on-status-bar-for-lollipop
I've tried to handle it in theme xmls but hit a dead end after a while: if partners would use multiple themes dynamically, not just the overriden `Default`, it wouldn't work.
(Otherwise working version about that approach is on branch `bugs/209-appbar-shadow-on-statusbar`)

So I looked up whether we can change status bar color from code and we can:
http://stackoverflow.com/a/26749343/4247460 
So I used this and it turned out to be a much simpler version than trying to do it with themes.