### PR TITLE
PR for 192: Backwards compatible tinted ProgressBar

### DIFF
--- a/eventdiscovery-demo/src/main/res/values/styles.xml
+++ b/eventdiscovery-demo/src/main/res/values/styles.xml
@@ -9,7 +9,7 @@
 
     <!-- this is how you customize the default theme -->
     <style name="SchedJoules_Theme.Default" tools:override="true" parent="SchedJoules_Theme.Light">
-        <item name="colorAccent">#2196F3</item>
+        <item name="colorAccent">#f57f17</item>
     </style>
 
 </resources>

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListFragment.java
@@ -21,8 +21,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.databinding.DataBindingUtil;
-import android.graphics.PorterDuff;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -155,13 +153,6 @@ public final class EventListFragment extends BaseFragment implements EventListMe
         });
         new SimpleCoverageTest(mCoverageDoveCote).execute(getActivity());
 
-        if (Build.VERSION.SDK_INT < 21)
-        {
-            // on older Version the progressbar won't pick up the accent color, so we have to set it manually
-            mViews.schedjoulesEventListProgressBar.getIndeterminateDrawable()
-                    .setColorFilter(getResources().getColor(R.color.schedjoules_colorAccent),
-                            PorterDuff.Mode.MULTIPLY);
-        }
         return mViews.getRoot();
     }
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/view/EventListLoadingIndicatorOverlay.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/view/EventListLoadingIndicatorOverlay.java
@@ -18,7 +18,6 @@
 package com.schedjoules.eventdiscovery.framework.eventlist.view;
 
 import android.view.View;
-import android.widget.ProgressBar;
 
 
 /**
@@ -28,10 +27,10 @@ import android.widget.ProgressBar;
  */
 public final class EventListLoadingIndicatorOverlay
 {
-    private final ProgressBar mProgressBar;
+    private final View mProgressBar;
 
 
-    public EventListLoadingIndicatorOverlay(ProgressBar progressBar)
+    public EventListLoadingIndicatorOverlay(View progressBar)
     {
         mProgressBar = progressBar;
     }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ActionLoaderMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ActionLoaderMicroFragment.java
@@ -19,8 +19,6 @@ package com.schedjoules.eventdiscovery.framework.microfragments.eventdetails;
 
 import android.content.Context;
 import android.databinding.DataBindingUtil;
-import android.graphics.PorterDuff;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -163,14 +161,6 @@ public final class ActionLoaderMicroFragment implements MicroFragment<Event>
                     R.layout.schedjoules_fragment_event_details_action_loading, container, false);
 
             new EventHeaderView(getActivity(), views.schedjoulesDetailsHeader).update(mEvent);
-
-            if (Build.VERSION.SDK_INT < 21)
-            {
-                // on older Version the progressbar won't pick up the accent color, so we have to set it manually
-                views.schedjoulesEventDetailsHorizontalActionsProgressbar.getIndeterminateDrawable()
-                        .setColorFilter(getResources().getColor(R.color.schedjoules_colorAccent),
-                                PorterDuff.Mode.MULTIPLY);
-            }
 
             return views.getRoot();
         }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/EventLoaderMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/EventLoaderMicroFragment.java
@@ -18,8 +18,6 @@
 package com.schedjoules.eventdiscovery.framework.microfragments.eventdetails;
 
 import android.content.Context;
-import android.graphics.PorterDuff;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.support.annotation.NonNull;
@@ -28,7 +26,6 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ProgressBar;
 
 import com.schedjoules.client.eventsdiscovery.Event;
 import com.schedjoules.client.eventsdiscovery.queries.EventByUid;
@@ -167,14 +164,6 @@ public final class EventLoaderMicroFragment implements MicroFragment<String>
             View view = inflater.inflate(R.layout.schedjoules_fragment_event_details_loading, container, false);
             view.findViewById(android.R.id.message).animate().setStartDelay(1500).alpha(1).start();
             ((CollapsingToolbarLayout) view.findViewById(R.id.schedjoules_event_detail_toolbar_layout)).setTitle("Loading event …");
-
-            if (Build.VERSION.SDK_INT < 21)
-            {
-                // on older Version the progressbar won't pick up the accent color, so we have to set it manually
-                ((ProgressBar) view.findViewById(R.id.schedjoules_event_details_horizontal_actions_progressbar)).getIndeterminateDrawable()
-                        .setColorFilter(getResources().getColor(R.color.schedjoules_colorAccent),
-                                PorterDuff.Mode.MULTIPLY);
-            }
 
             return view;
         }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/views/ActionView.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/views/ActionView.java
@@ -75,7 +75,7 @@ public final class ActionView implements SmartView<Optional<Action>>
 
             mTextView.setText(action.label(context));
 
-            Drawable icon = TintedDrawable.tint(action.icon(context), new AttributeColor(context, R.attr.colorAccent));
+            Drawable icon = TintedDrawable.tinted(action.icon(context), new AttributeColor(context, R.attr.colorAccent));
             mTextView.setCompoundDrawablesWithIntrinsicBounds(icon, null, null, null);
 
             mRoot.setOnClickListener(new ActionClickListener(action.actionExecutable()));

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/TintedDrawable.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/TintedDrawable.java
@@ -39,14 +39,14 @@ public final class TintedDrawable
      */
     public static Drawable create(Context context, @DrawableRes int drawableResId, Color color)
     {
-        return tint(ContextCompat.getDrawable(context, drawableResId), color);
+        return tinted(ContextCompat.getDrawable(context, drawableResId), color);
     }
 
 
     /**
      * Returns a tinted version of the given drawable.
      */
-    public static Drawable tint(Drawable drawable, Color color)
+    public static Drawable tinted(Drawable drawable, Color color)
     {
         Drawable mutated = DrawableCompat.wrap(drawable).mutate();
         DrawableCompat.setTint(mutated, color.argb());

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/widgets/AccentColoredProgressBar.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/widgets/AccentColoredProgressBar.java
@@ -51,8 +51,7 @@ public final class AccentColoredProgressBar extends ProgressBar
         Drawable indeterminateDrawable = getIndeterminateDrawable();
         if (indeterminateDrawable != null)
         {
-            setIndeterminateDrawable(TintedDrawable.tint(indeterminateDrawable, new AttributeColor(getContext(), R.attr.colorAccent)));
-
+            setIndeterminateDrawable(TintedDrawable.tinted(indeterminateDrawable, new AttributeColor(getContext(), R.attr.colorAccent)));
         }
     }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/widgets/AccentColoredProgressBar.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/widgets/AccentColoredProgressBar.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.widgets;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.widget.ProgressBar;
+
+import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.utils.AttributeColor;
+import com.schedjoules.eventdiscovery.framework.utils.TintedDrawable;
+
+
+/**
+ * {@link ProgressBar} that tints the indeterminate drawable with accent color on pre-Lollipop versions.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class AccentColoredProgressBar extends ProgressBar
+{
+    public AccentColoredProgressBar(Context context, AttributeSet attrs)
+    {
+        super(context, attrs);
+
+        if (Build.VERSION.SDK_INT < 21)
+        {
+            tintIndeterminateDrawable();
+        }
+    }
+
+
+    private void tintIndeterminateDrawable()
+    {
+        Drawable indeterminateDrawable = getIndeterminateDrawable();
+        if (indeterminateDrawable != null)
+        {
+            setIndeterminateDrawable(TintedDrawable.tint(indeterminateDrawable, new AttributeColor(getContext(), R.attr.colorAccent)));
+
+        }
+    }
+}

--- a/eventdiscovery-sdk/src/main/res/layout-v21/schedjoules_fragment_event_list.xml
+++ b/eventdiscovery-sdk/src/main/res/layout-v21/schedjoules_fragment_event_list.xml
@@ -52,7 +52,7 @@
                     android:gravity="center"
                     android:layout_gravity="center"/>
 
-            <ProgressBar
+            <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
                     android:id="@+id/schedjoules_event_list_progress_bar"
                     android:layout_gravity="center"
                     android:visibility="gone"

--- a/eventdiscovery-sdk/src/main/res/layout-v21/schedjoules_fragment_webview.xml
+++ b/eventdiscovery-sdk/src/main/res/layout-v21/schedjoules_fragment_webview.xml
@@ -27,7 +27,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"/>
 
-        <ProgressBar
+        <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
                 android:id="@android:id/progress"
                 style="@style/Widget.AppCompat.ProgressBar.Horizontal"
                 android:layout_width="match_parent"

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_details_action_loading.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_details_action_loading.xml
@@ -22,7 +22,7 @@
                 android:id="@+id/schedjoules_event_detail_container"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-            <ProgressBar
+            <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
                     android:id="@+id/schedjoules_event_details_horizontal_actions_progressbar"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_details_loading.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_details_loading.xml
@@ -21,7 +21,7 @@
                 app:layout_behavior="@string/appbar_scrolling_view_behavior"
                 android:animateLayoutChanges="true">
 
-            <ProgressBar
+            <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
                     android:id="@+id/schedjoules_event_details_horizontal_actions_progressbar"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list.xml
@@ -53,7 +53,7 @@
                     android:gravity="center"
                     android:layout_gravity="center"/>
 
-            <ProgressBar
+            <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
                     android:id="@+id/schedjoules_event_list_progress_bar"
                     android:layout_gravity="center"
                     android:visibility="gone"

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_loading_feedback.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_loading_feedback.xml
@@ -26,7 +26,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-            <ProgressBar
+            <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
                     android:id="@android:id/progress"
                     style="@style/Widget.AppCompat.ProgressBar.Horizontal"
                     android:layout_width="match_parent"

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_webview.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_webview.xml
@@ -28,7 +28,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"/>
 
-        <ProgressBar
+        <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
                 android:id="@android:id/progress"
                 style="@style/Widget.AppCompat.ProgressBar.Horizontal"
                 android:layout_width="match_parent"

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_list_item_loading.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_list_item_loading.xml
@@ -3,10 +3,9 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/schedjoules_list_item_default_height">
 
-    <ProgressBar
+    <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
             android:layout_width="36dp"
             android:layout_height="36dp"
-            android:indeterminateTint="?attr/colorAccent"
             android:layout_gravity="center"/>
 
 </FrameLayout>


### PR DESCRIPTION
Implements #192.

I've change the accent color of the demo app from blue to orange because apparently the `ProgressBar` horizontal default color on pre-Lollipop is a very similar blue. (It take away about half an hour..). So to avoid missing problems with the accent color, I've changed it.

The new tinted horizontal ProgressBar animation on pre-Lollipop looks different for some reason compared to how it looks like without it. So originally the line is moving fast all across the width, now it starts slowly from the left. Please check it out if it's okay like this or should I spend time to try to fix this. It doesn't look too bad imo and it may not be worth spending time on older version look fine tuning.