### PR TITLE
PR for 243: Upgrade Android support libraries to latest version

### DIFF
--- a/eventdiscovery-demo/build.gradle
+++ b/eventdiscovery-demo/build.gradle
@@ -28,12 +28,12 @@ def gitCommitNo = { ->
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.0"
+    compileSdkVersion COMPILE_SDK_VERSION.toInteger()
+    buildToolsVersion BUILD_TOOLS_VERSION
     defaultConfig {
         applicationId "com.schedjoules.eventdiscovery.demo"
-        minSdkVersion 14
-        targetSdkVersion 23
+        minSdkVersion MIN_SDK_VERSION.toInteger()
+        targetSdkVersion TARGET_SDK_VERSION.toInteger()
         versionCode gitCommitNo() * 10 // spread the version number so we can insert versions if necessary
         versionName gitVersion()
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -82,6 +82,6 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:' + SUPPORT_LIBRARY_VERSION
     compile project(path: ':eventdiscovery-sdk')
 }

--- a/eventdiscovery-sdk/build.gradle
+++ b/eventdiscovery-sdk/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.0"
+    compileSdkVersion COMPILE_SDK_VERSION.toInteger()
+    buildToolsVersion BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 23
+        minSdkVersion MIN_SDK_VERSION.toInteger()
+        targetSdkVersion TARGET_SDK_VERSION.toInteger()
         versionCode 1
         versionName "0.1"
 
@@ -53,10 +53,10 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:design:23.4.0'
-    compile 'com.android.support:cardview-v7:23.4.0'
-    compile 'com.android.support:recyclerview-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:' + SUPPORT_LIBRARY_VERSION
+    compile 'com.android.support:design:' + SUPPORT_LIBRARY_VERSION
+    compile 'com.android.support:cardview-v7:' + SUPPORT_LIBRARY_VERSION
+    compile 'com.android.support:recyclerview-v7:' + SUPPORT_LIBRARY_VERSION
     compile 'org.dmfs:rfc5545-datetime:0.2.4'
     compile 'org.dmfs:rfc3986-uri:0.7'
     compile 'org.dmfs:http-client-types:' + HTTP_CLIENT_ESSENTIALS_VERSION
@@ -79,7 +79,7 @@ dependencies {
     testCompile 'org.powermock:powermock-module-junit4:1.7.0RC2'
     testCompile 'org.powermock:powermock-api-mockito2:1.7.0RC2'
 
-    androidTestCompile 'com.android.support:support-annotations:23.4.0'
+    androidTestCompile 'com.android.support:support-annotations:' + SUPPORT_LIBRARY_VERSION
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,9 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+COMPILE_SDK_VERSION=25
+BUILD_TOOLS_VERSION=25.0.3
+MIN_SDK_VERSION=14
+TARGET_SDK_VERSION=23
+SUPPORT_LIBRARY_VERSION=25.0.1
 HTTP_CLIENT_ESSENTIALS_VERSION=0.10.3


### PR DESCRIPTION
Implements #243.

@dmfs I've added gradle variables for `compileSdkVersion, buildToolsVersion, minSdkVersion, targetSdkVersion` as well, although I remember you had some concern about that, but I forgot. I can remove them of course. I thought that if `HTTP_CLIENT_ESSENTIALS_VERSION` works without problem than those should be okay as well.