### PR TITLE
Fix CURRENT LOCATION text color on pre-Lollipop versions with latest …

### DIFF
--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_list_item_location_button.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_list_item_location_button.xml
@@ -11,6 +11,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:textAppearance="@style/Widget.AppCompat.Button.Borderless.Colored"
+            android:textColor="?attr/colorAccent"
             android:padding="16dp"
             android:textSize="16sp"
             android:textAllCaps="true"


### PR DESCRIPTION
…support library usage. #252 

Note, that the bug doesn't occur now with support library version `25.0.1` but it will come back with `25.3.x`, so I figured we can add that one line now so it's not forgotten later.