### PR TITLE
Move event list items loading and displaying related code into new ch…

### DIFF
--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListFragment.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.eventlist;
+
+import android.databinding.DataBindingUtil;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.schedjoules.client.eventsdiscovery.GeoLocation;
+import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.databinding.SchedjoulesEventListBinding;
+import com.schedjoules.eventdiscovery.framework.common.BaseFragment;
+import com.schedjoules.eventdiscovery.framework.eventlist.controller.EventListController;
+import com.schedjoules.eventdiscovery.framework.eventlist.controller.EventListControllerImpl;
+import com.schedjoules.eventdiscovery.framework.eventlist.controller.FlexibleAdapterEventListItems;
+import com.schedjoules.eventdiscovery.framework.eventlist.flexibleadapter.Copying;
+import com.schedjoules.eventdiscovery.framework.eventlist.flexibleadapter.FlexibleAdapterFactory;
+import com.schedjoules.eventdiscovery.framework.eventlist.view.EdgeReachScrollListener;
+import com.schedjoules.eventdiscovery.framework.eventlist.view.EventListBackgroundMessage;
+import com.schedjoules.eventdiscovery.framework.eventlist.view.EventListLoadingIndicatorOverlay;
+import com.schedjoules.eventdiscovery.framework.locationpicker.SharedPrefLastSelectedPlace;
+import com.schedjoules.eventdiscovery.framework.serialization.Keys;
+import com.schedjoules.eventdiscovery.framework.serialization.commons.OptionalArgument;
+import com.schedjoules.eventdiscovery.framework.utils.FutureServiceConnection;
+import com.schedjoules.eventdiscovery.framework.utils.factory.Factory;
+import com.schedjoules.eventdiscovery.service.ApiService;
+
+import org.dmfs.rfc5545.DateTime;
+
+import eu.davidea.flexibleadapter.FlexibleAdapter;
+import eu.davidea.flexibleadapter.items.IFlexible;
+
+
+/**
+ * Fragment for the event item list on the list screen.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class EventListListFragment extends BaseFragment
+{
+    private FutureServiceConnection<ApiService> mApiService;
+    private EventListController mListItemsController;
+    private FlexibleAdapter<IFlexible> mAdapter;
+    private SchedjoulesEventListBinding mViews;
+
+
+    public static Fragment newInstance(Bundle args)
+    {
+        EventListListFragment fragment = new EventListListFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+        setRetainInstance(true);
+
+        mApiService = new ApiService.FutureConnection(getActivity());
+
+        mListItemsController = new EventListControllerImpl(mApiService, new FlexibleAdapterEventListItems());
+    }
+
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
+    {
+        mViews = DataBindingUtil.inflate(inflater, R.layout.schedjoules_event_list, container, false);
+
+        mListItemsController.setBackgroundMessageUI(
+                new EventListBackgroundMessage(mViews.schedjoulesEventListBackgroundMessage));
+        mListItemsController.setLoadingIndicatorUI(
+                new EventListLoadingIndicatorOverlay(mViews.schedjoulesEventListProgressBar));
+
+        update(savedInstanceState == null);
+
+        return mViews.getRoot();
+    }
+
+
+    private void update(boolean freshList)
+    {
+        initAdapterAndRecyclerView(freshList);
+        if (freshList)
+        {
+            mListItemsController.loadEvents(location(), startAfter());
+        }
+    }
+
+
+    private void initAdapterAndRecyclerView(boolean freshList)
+    {
+        Factory<FlexibleAdapter<IFlexible>> adapterFactory = new FlexibleAdapterFactory();
+        if (!freshList && mAdapter != null)
+        {
+            adapterFactory = new Copying(adapterFactory, mAdapter);
+        }
+        FlexibleAdapter<IFlexible> adapter = adapterFactory.create();
+
+        RecyclerView recyclerView = mViews.schedjoulesEventList;
+        recyclerView.setAdapter(adapter);
+        adapter.setStickyHeaders(true); // Better to set it after adapter has been set to RecyclerView
+        recyclerView.addOnScrollListener(
+                new EdgeReachScrollListener(recyclerView, mListItemsController,
+                        EventListControllerImpl.CLOSE_TO_TOP_OR_BOTTOM_THRESHOLD));
+
+        mListItemsController.setAdapter(adapter);
+        mAdapter = adapter;
+    }
+
+
+    @Override
+    public void onDestroy()
+    {
+        super.onDestroy();
+        mApiService.disconnect();
+    }
+
+
+    private GeoLocation location()
+    {
+        if (new OptionalArgument<>(Keys.GEO_LOCATION, getArguments()).isPresent())
+        {
+            // TODO Save location and update Toolbar title with name when Event Discovery for input geo-location is actually supported
+            throw new UnsupportedOperationException("Discovery for a geo location not supported yet.");
+        }
+        return new SharedPrefLastSelectedPlace(getContext()).get().geoLocation();
+    }
+
+
+    private DateTime startAfter()
+    {
+        return new OptionalArgument<>(Keys.DATE_TIME_START_AFTER, this).value(DateTime.nowAndHere());
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/res/layout-v21/schedjoules_fragment_event_list.xml
+++ b/eventdiscovery-sdk/src/main/res/layout-v21/schedjoules_fragment_event_list.xml
@@ -37,27 +37,10 @@
                 android:layout_height="match_parent"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-            <include
-                    android:id="@+id/schedjoules_event_list_include"
-                    layout="@layout/schedjoules_event_list"/>
-
-            <com.schedjoules.eventdiscovery.framework.widgets.StateSavingTextView
-                    android:id="@+id/schedjoules_event_list_background_message"
+            <FrameLayout
+                    android:id="@+id/schedjoules_event_list_list_holder"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_margin="@dimen/schedjoules_activity_horizontal_margin"
-                    android:paddingBottom="30dp"
-                    android:textSize="16sp"
-                    android:visibility="gone"
-                    android:gravity="center"
-                    android:layout_gravity="center"/>
-
-            <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
-                    android:id="@+id/schedjoules_event_list_progress_bar"
-                    android:layout_gravity="center"
-                    android:visibility="gone"
-                    android:layout_width="@dimen/schedjoules_event_list_progress_bar"
-                    android:layout_height="@dimen/schedjoules_event_list_progress_bar"/>
+                    android:layout_height="match_parent"/>
 
         </FrameLayout>
 

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_event_list.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_event_list.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools">
+        xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <FrameLayout
             android:layout_width="match_parent"
@@ -15,9 +14,25 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:layoutManager="LinearLayoutManager"
-                android:layout_marginBottom="24dp"
-                tools:context=".framework.eventlist.EventListActivity"
-                tools:listitem="@layout/schedjoules_list_item_event"/>
+                android:layout_marginBottom="24dp"/>
+
+        <com.schedjoules.eventdiscovery.framework.widgets.StateSavingTextView
+                android:id="@+id/schedjoules_event_list_background_message"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_margin="@dimen/schedjoules_activity_horizontal_margin"
+                android:paddingBottom="30dp"
+                android:textSize="16sp"
+                android:visibility="gone"
+                android:gravity="center"
+                android:layout_gravity="center"/>
+
+        <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
+                android:id="@+id/schedjoules_event_list_progress_bar"
+                android:layout_gravity="center"
+                android:visibility="gone"
+                android:layout_width="@dimen/schedjoules_event_list_progress_bar"
+                android:layout_height="@dimen/schedjoules_event_list_progress_bar"/>
 
         <com.schedjoules.eventdiscovery.framework.microfragments.eventdetails.fragments.views.SchedJoulesFooterView xmlns:app="http://schemas.android.com/apk/res-auto"
                 xmlns:android="http://schemas.android.com/apk/res/android"

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list.xml
@@ -38,27 +38,10 @@
                 app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
 
-            <include
-                    android:id="@+id/schedjoules_event_list_include"
-                    layout="@layout/schedjoules_event_list"/>
-
-            <com.schedjoules.eventdiscovery.framework.widgets.StateSavingTextView
-                    android:id="@+id/schedjoules_event_list_background_message"
+            <FrameLayout
+                    android:id="@+id/schedjoules_event_list_list_holder"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_margin="@dimen/schedjoules_activity_horizontal_margin"
-                    android:paddingBottom="30dp"
-                    android:textSize="16sp"
-                    android:visibility="gone"
-                    android:gravity="center"
-                    android:layout_gravity="center"/>
-
-            <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
-                    android:id="@+id/schedjoules_event_list_progress_bar"
-                    android:layout_gravity="center"
-                    android:visibility="gone"
-                    android:layout_width="@dimen/schedjoules_event_list_progress_bar"
-                    android:layout_height="@dimen/schedjoules_event_list_progress_bar"/>
+                    android:layout_height="match_parent"/>
 
             <View
                     android:layout_gravity="top"


### PR DESCRIPTION
…ild fragment. #262 

---

I've moved the actual list related code into a new `EventListListFragment` which is used as a child fragment of `EventListFragment`.
`EventListFragment` still contains all the Toolbar stuff, I haven't separated that to a fragment because it's not need at this stage and maybe not needed later either. There will be some things to figure out/decide about how to show the categories filter on the very first load. So I just want to defer any decision to where we actually have to make it.

Next step is to make the current `EventListListFragment` a `MicroFragmentHost` and create its loader, error, and show MFs.

The change in this PR - which went surprisingly without issues - already reduces complexity, for example the former `onResume()` logic disappeared (!). So I think this could be merged to master instead of the categories-master.