### PR TITLE
Upgrade MicroFragments to latest version. Implements #266

### DIFF
--- a/eventdiscovery-sdk/build.gradle
+++ b/eventdiscovery-sdk/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     compile 'org.dmfs:http-client-types:' + HTTP_CLIENT_ESSENTIALS_VERSION
     compile 'org.dmfs:http-executor-decorators:' + HTTP_CLIENT_ESSENTIALS_VERSION
     compile 'org.dmfs:httpurlconnection-executor:' + HTTP_CLIENT_ESSENTIALS_VERSION
-    compile 'com.github.dmfs:MicroFragments:e12ac1615e07fb0a9012f32267696a48fda0f69b'
+    compile 'com.github.dmfs:MicroFragments:aa52c346c7be35b207b8619924ee049e52516cae'
     compile 'com.github.schedjoules:java-api-client:0.6'
     compile 'com.github.bumptech.glide:glide:3.7.0'
     compile 'com.github.dmfs:multiline-collapsingtoolbar:79a3e4520261300cf32f2954832173bef2a43a40'

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ActionLoaderMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ActionLoaderMicroFragment.java
@@ -39,7 +39,6 @@ import com.schedjoules.eventdiscovery.framework.utils.ServiceJob;
 import com.schedjoules.eventdiscovery.framework.utils.ServiceJobQueue;
 import com.schedjoules.eventdiscovery.framework.utils.SimpleServiceJobQueue;
 
-import org.dmfs.android.microfragments.BasicMicroFragmentEnvironment;
 import org.dmfs.android.microfragments.FragmentEnvironment;
 import org.dmfs.android.microfragments.MicroFragment;
 import org.dmfs.android.microfragments.MicroFragmentHost;
@@ -100,17 +99,13 @@ public final class ActionLoaderMicroFragment implements MicroFragment<Event>
     @Override
     public Fragment fragment(@NonNull Context context, MicroFragmentHost host)
     {
-        Fragment result = new LoaderFragment();
-        Bundle args = new Bundle(1);
-        args.putParcelable(MicroFragment.ARG_ENVIRONMENT, new BasicMicroFragmentEnvironment<>(this, host));
-        result.setArguments(args);
-        return result;
+        return new LoaderFragment();
     }
 
 
     @NonNull
     @Override
-    public Event parameters()
+    public Event parameter()
     {
         return mEvent;
     }
@@ -149,7 +144,7 @@ public final class ActionLoaderMicroFragment implements MicroFragment<Event>
         {
             super.onCreate(savedInstanceState);
             mActionServiceJobQueue = new SimpleServiceJobQueue<>(new ActionService.FutureConnection(getActivity()));
-            mEvent = new FragmentEnvironment<Event>(this).microFragment().parameters();
+            mEvent = new FragmentEnvironment<Event>(this).microFragment().parameter();
         }
 
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ErrorMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ErrorMicroFragment.java
@@ -32,7 +32,6 @@ import com.schedjoules.eventdiscovery.R;
 
 import net.opacapp.multilinecollapsingtoolbar.CollapsingToolbarLayout;
 
-import org.dmfs.android.microfragments.BasicMicroFragmentEnvironment;
 import org.dmfs.android.microfragments.FragmentEnvironment;
 import org.dmfs.android.microfragments.MicroFragment;
 import org.dmfs.android.microfragments.MicroFragmentHost;
@@ -95,17 +94,13 @@ public final class ErrorMicroFragment implements MicroFragment<ErrorMicroFragmen
     @Override
     public Fragment fragment(@NonNull Context context, @NonNull MicroFragmentHost microFragmentHost)
     {
-        Fragment result = new ErrorFragment();
-        Bundle args = new Bundle(1);
-        args.putParcelable(MicroFragment.ARG_ENVIRONMENT, new BasicMicroFragmentEnvironment<>(this, microFragmentHost));
-        result.setArguments(args);
-        return result;
+        return new ErrorFragment();
     }
 
 
     @NonNull
     @Override
-    public Error parameters()
+    public Error parameter()
     {
         return new Error()
         {
@@ -162,7 +157,7 @@ public final class ErrorMicroFragment implements MicroFragment<ErrorMicroFragmen
         public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
         {
             View view = inflater.inflate(R.layout.schedjoules_fragment_event_details_error, container, false);
-            Error error = new FragmentEnvironment<Error>(this).microFragment().parameters();
+            Error error = new FragmentEnvironment<Error>(this).microFragment().parameter();
             String title = error.title();
             String message = error.message();
             if (message != null)

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/EventLoaderMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/EventLoaderMicroFragment.java
@@ -38,7 +38,6 @@ import com.schedjoules.eventdiscovery.service.ApiService;
 
 import net.opacapp.multilinecollapsingtoolbar.CollapsingToolbarLayout;
 
-import org.dmfs.android.microfragments.BasicMicroFragmentEnvironment;
 import org.dmfs.android.microfragments.FragmentEnvironment;
 import org.dmfs.android.microfragments.MicroFragment;
 import org.dmfs.android.microfragments.MicroFragmentHost;
@@ -100,17 +99,13 @@ public final class EventLoaderMicroFragment implements MicroFragment<String>
     @Override
     public Fragment fragment(@NonNull Context context, MicroFragmentHost host)
     {
-        Fragment result = new LoaderFragment();
-        Bundle args = new Bundle(2);
-        args.putParcelable(MicroFragment.ARG_ENVIRONMENT, new BasicMicroFragmentEnvironment<>(this, host));
-        result.setArguments(args);
-        return result;
+        return new LoaderFragment();
     }
 
 
     @NonNull
     @Override
-    public String parameters()
+    public String parameter()
     {
         return mEventUid;
     }
@@ -153,7 +148,7 @@ public final class EventLoaderMicroFragment implements MicroFragment<String>
             super.onCreate(savedInstanceState);
             mActionServiceJobQueue = new SimpleServiceJobQueue<>(new ActionService.FutureConnection(getActivity()));
             mApiServiceJobQueue = new SimpleServiceJobQueue<>(new ApiService.FutureConnection(getActivity()));
-            mEventUid = new FragmentEnvironment<String>(this).microFragment().parameters();
+            mEventUid = new FragmentEnvironment<String>(this).microFragment().parameter();
         }
 
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ShowEventMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ShowEventMicroFragment.java
@@ -18,7 +18,6 @@
 package com.schedjoules.eventdiscovery.framework.microfragments.eventdetails;
 
 import android.content.Context;
-import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
@@ -29,7 +28,6 @@ import com.schedjoules.eventdiscovery.framework.microfragments.eventdetails.frag
 import com.schedjoules.eventdiscovery.framework.model.ParcelableEvent;
 import com.schedjoules.eventdiscovery.framework.model.ParcelableLink;
 
-import org.dmfs.android.microfragments.BasicMicroFragmentEnvironment;
 import org.dmfs.android.microfragments.MicroFragment;
 import org.dmfs.android.microfragments.MicroFragmentHost;
 import org.dmfs.httpessentials.types.Link;
@@ -93,17 +91,13 @@ public final class ShowEventMicroFragment implements MicroFragment<ShowEventMicr
     @Override
     public Fragment fragment(@NonNull Context context, MicroFragmentHost host)
     {
-        Fragment result = new EventDetailFragment();
-        Bundle args = new Bundle(2);
-        args.putParcelable(MicroFragment.ARG_ENVIRONMENT, new BasicMicroFragmentEnvironment<>(this, host));
-        result.setArguments(args);
-        return result;
+        return new EventDetailFragment();
     }
 
 
     @NonNull
     @Override
-    public EventParams parameters()
+    public EventParams parameter()
     {
         return new EventParams()
         {

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/EventDetailFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/EventDetailFragment.java
@@ -56,7 +56,7 @@ public final class EventDetailFragment extends BaseFragment implements EventDeta
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
     {
-        ShowEventMicroFragment.EventParams parameters = new FragmentEnvironment<ShowEventMicroFragment.EventParams>(this).microFragment().parameters();
+        ShowEventMicroFragment.EventParams parameters = new FragmentEnvironment<ShowEventMicroFragment.EventParams>(this).microFragment().parameter();
 
         if (savedInstanceState == null)
         {

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/feedback/FeedbackMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/feedback/FeedbackMicroFragment.java
@@ -37,7 +37,6 @@ import com.schedjoules.eventdiscovery.framework.utils.ServiceJobQueue;
 import com.schedjoules.eventdiscovery.framework.utils.SimpleServiceJobQueue;
 import com.schedjoules.eventdiscovery.service.ApiService;
 
-import org.dmfs.android.microfragments.BasicMicroFragmentEnvironment;
 import org.dmfs.android.microfragments.FragmentEnvironment;
 import org.dmfs.android.microfragments.MicroFragment;
 import org.dmfs.android.microfragments.MicroFragmentEnvironment;
@@ -96,19 +95,15 @@ public final class FeedbackMicroFragment implements MicroFragment<Void>
     @Override
     public Fragment fragment(@NonNull Context context, MicroFragmentHost host)
     {
-        Fragment result = new LoaderFragment();
-        Bundle args = new Bundle(1);
-        args.putParcelable(MicroFragment.ARG_ENVIRONMENT, new BasicMicroFragmentEnvironment<>(this, host));
-        result.setArguments(args);
-        return result;
+        return new LoaderFragment();
     }
 
 
     @NonNull
     @Override
-    public Void parameters()
+    public Void parameter()
     {
-        return null;
+        throw new UnsupportedOperationException("FeedbackMicroFragment has no parameters.");
     }
 
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/webview/WebviewMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/webview/WebviewMicroFragment.java
@@ -40,7 +40,6 @@ import android.widget.ProgressBar;
 
 import com.schedjoules.eventdiscovery.R;
 
-import org.dmfs.android.microfragments.BasicMicroFragmentEnvironment;
 import org.dmfs.android.microfragments.FragmentEnvironment;
 import org.dmfs.android.microfragments.MicroFragment;
 import org.dmfs.android.microfragments.MicroFragmentEnvironment;
@@ -95,17 +94,13 @@ public final class WebviewMicroFragment implements MicroFragment<URI>
     @Override
     public Fragment fragment(@NonNull Context context, @NonNull MicroFragmentHost host)
     {
-        Fragment result = new WebviewFragment();
-        Bundle args = new Bundle();
-        args.putParcelable(MicroFragment.ARG_ENVIRONMENT, new BasicMicroFragmentEnvironment<>(this, host));
-        result.setArguments(args);
-        return result;
+        return new WebviewFragment();
     }
 
 
     @NonNull
     @Override
-    public URI parameters()
+    public URI parameter()
     {
         return mUrl;
     }
@@ -169,7 +164,7 @@ public final class WebviewMicroFragment implements MicroFragment<URI>
 
             if (savedInstanceState == null)
             {
-                mWebView.loadUrl(mEnvironment.microFragment().parameters().toASCIIString());
+                mWebView.loadUrl(mEnvironment.microFragment().parameter().toASCIIString());
                 // TODO: make this optional
                 // wipe cookies to enforce a new login
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1)


### PR DESCRIPTION
With the new version MicroFragments no longer have to add the FragmentEnvironment themselves to the Fragment arguments.
Also, the back button is handled by the hosting activity now and not by the HostFragment.