### PR TITLE
Fix event list reloading when coming back from event details. #273

### DIFF
--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListFragment.java
@@ -63,6 +63,8 @@ public final class EventListListFragment extends BaseFragment
     private FlexibleAdapter<IFlexible> mAdapter;
     private SchedjoulesEventListBinding mViews;
 
+    private boolean mIsInitializing = true;
+
 
     public static Fragment newInstance(Bundle args)
     {
@@ -95,26 +97,21 @@ public final class EventListListFragment extends BaseFragment
         mListItemsController.setLoadingIndicatorUI(
                 new EventListLoadingIndicatorOverlay(mViews.schedjoulesEventListProgressBar));
 
-        update(savedInstanceState == null);
+        initAdapterAndRecyclerView(mIsInitializing);
+        if (mIsInitializing)
+        {
+            mListItemsController.loadEvents(location(), startAfter());
+        }
 
+        mIsInitializing = false;
         return mViews.getRoot();
     }
 
 
-    private void update(boolean freshList)
-    {
-        initAdapterAndRecyclerView(freshList);
-        if (freshList)
-        {
-            mListItemsController.loadEvents(location(), startAfter());
-        }
-    }
-
-
-    private void initAdapterAndRecyclerView(boolean freshList)
+    private void initAdapterAndRecyclerView(boolean isInitializing)
     {
         Factory<FlexibleAdapter<IFlexible>> adapterFactory = new FlexibleAdapterFactory();
-        if (!freshList && mAdapter != null)
+        if (!isInitializing && mAdapter != null)
         {
             adapterFactory = new Copying(adapterFactory, mAdapter);
         }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/EventDetailFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/EventDetailFragment.java
@@ -40,6 +40,8 @@ import com.schedjoules.eventdiscovery.framework.microfragments.eventdetails.frag
 import com.schedjoules.eventdiscovery.framework.utils.InsightsTask;
 
 import org.dmfs.android.microfragments.FragmentEnvironment;
+import org.dmfs.android.microfragments.MicroFragmentEnvironment;
+import org.dmfs.android.microfragments.transitions.BackTransition;
 import org.dmfs.httpessentials.types.StringToken;
 
 
@@ -56,7 +58,8 @@ public final class EventDetailFragment extends BaseFragment implements EventDeta
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
     {
-        ShowEventMicroFragment.EventParams parameters = new FragmentEnvironment<ShowEventMicroFragment.EventParams>(this).microFragment().parameter();
+        final MicroFragmentEnvironment<ShowEventMicroFragment.EventParams> environment = new FragmentEnvironment<>(this);
+        ShowEventMicroFragment.EventParams parameters = environment.microFragment().parameter();
 
         if (savedInstanceState == null)
         {
@@ -76,7 +79,7 @@ public final class EventDetailFragment extends BaseFragment implements EventDeta
             @Override
             public void onClick(View view)
             {
-                getActivity().finish();
+                environment.host().execute(getActivity(), new BackTransition());
             }
         });
         toolbar.setOnMenuItemClickListener(new Toolbar.OnMenuItemClickListener()


### PR DESCRIPTION
---

This will need to be rebased on `categories/master` first after #72 is closed.

This fix is only applicable now to retained fragments, if we encounter any other problem with normal fragments popped from back stack, we need to revisit the general topic. @dmfs the spreadsheet I shared with you contains I think a good overview of the lifecycles, so we can look into that again, if needed.

I've also changed the UP navigation in the Details MF to fire the BackTransition as you said.