### PR TITLE
Create splash loading MicroFragment for the list screen. #276

### DIFF
--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/discovery/BasicEventDiscovery.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/discovery/BasicEventDiscovery.java
@@ -23,7 +23,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.StyleRes;
 
 import com.schedjoules.client.eventsdiscovery.GeoLocation;
-import com.schedjoules.eventdiscovery.framework.eventlist.EventListMicroFragment;
+import com.schedjoules.eventdiscovery.framework.eventlist.EventListLoaderMicroFragment;
 import com.schedjoules.eventdiscovery.framework.serialization.Keys;
 import com.schedjoules.eventdiscovery.framework.serialization.boxes.DateTimeBox;
 import com.schedjoules.eventdiscovery.framework.serialization.boxes.GeoLocationBox;
@@ -95,9 +95,9 @@ public final class BasicEventDiscovery implements EventDiscovery
     @Override
     public void start(@NonNull Activity activity)
     {
-        Intent intent = mIntentBuilder.with(Keys.MICRO_FRAGMENT, new ParcelableBox<MicroFragment>(
-                new EventListMicroFragment(new NestedBundle(mIntentBuilder.build()).get()))).build();
-
-        activity.startActivity(intent.setPackage(activity.getPackageName()));
+        activity.startActivity(mIntentBuilder
+                .with(Keys.MICRO_FRAGMENT, new ParcelableBox<MicroFragment>(
+                        new EventListLoaderMicroFragment(new NestedBundle(mIntentBuilder.build()).get())))
+                .build().setPackage(activity.getPackageName()));
     }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListFragment.java
@@ -26,13 +26,17 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.schedjoules.client.eventsdiscovery.Envelope;
+import com.schedjoules.client.eventsdiscovery.Event;
 import com.schedjoules.client.eventsdiscovery.GeoLocation;
+import com.schedjoules.client.eventsdiscovery.ResultPage;
 import com.schedjoules.eventdiscovery.R;
 import com.schedjoules.eventdiscovery.databinding.SchedjoulesEventListBinding;
 import com.schedjoules.eventdiscovery.framework.common.BaseFragment;
 import com.schedjoules.eventdiscovery.framework.eventlist.controller.EventListController;
 import com.schedjoules.eventdiscovery.framework.eventlist.controller.EventListControllerImpl;
 import com.schedjoules.eventdiscovery.framework.eventlist.controller.FlexibleAdapterEventListItems;
+import com.schedjoules.eventdiscovery.framework.eventlist.controller.InitialEventsDiscovery;
 import com.schedjoules.eventdiscovery.framework.eventlist.flexibleadapter.Copying;
 import com.schedjoules.eventdiscovery.framework.eventlist.flexibleadapter.FlexibleAdapterFactory;
 import com.schedjoules.eventdiscovery.framework.eventlist.view.EdgeReachScrollListener;
@@ -100,7 +104,15 @@ public final class EventListListFragment extends BaseFragment
         initAdapterAndRecyclerView(mIsInitializing);
         if (mIsInitializing)
         {
-            mListItemsController.loadEvents(location(), startAfter());
+            OptionalArgument<ResultPage<Envelope<Event>>> resultPage = new OptionalArgument<>(Keys.EVENTS_RESULT_PAGE, this);
+            if (resultPage.isPresent())
+            {
+                mListItemsController.showEvents(resultPage.value());
+            }
+            else
+            {
+                mListItemsController.loadEvents(new InitialEventsDiscovery(startAfter(), location()));
+            }
         }
 
         mIsInitializing = false;

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListLoaderMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListLoaderMicroFragment.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.eventlist;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.schedjoules.client.eventsdiscovery.Envelope;
+import com.schedjoules.client.eventsdiscovery.Event;
+import com.schedjoules.client.eventsdiscovery.GeoLocation;
+import com.schedjoules.client.eventsdiscovery.ResultPage;
+import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.common.BaseFragment;
+import com.schedjoules.eventdiscovery.framework.eventlist.controller.InitialEventsDiscovery;
+import com.schedjoules.eventdiscovery.framework.locationpicker.SharedPrefLastSelectedPlace;
+import com.schedjoules.eventdiscovery.framework.serialization.Keys;
+import com.schedjoules.eventdiscovery.framework.serialization.boxes.EventResultPageBox;
+import com.schedjoules.eventdiscovery.framework.serialization.commons.BundleBuilder;
+import com.schedjoules.eventdiscovery.framework.serialization.commons.OptionalArgument;
+import com.schedjoules.eventdiscovery.framework.utils.ServiceJob;
+import com.schedjoules.eventdiscovery.framework.utils.SimpleServiceJobQueue;
+import com.schedjoules.eventdiscovery.service.ApiService;
+
+import org.dmfs.android.microfragments.FragmentEnvironment;
+import org.dmfs.android.microfragments.MicroFragment;
+import org.dmfs.android.microfragments.MicroFragmentHost;
+import org.dmfs.android.microfragments.Timestamp;
+import org.dmfs.android.microfragments.timestamps.UiTimestamp;
+import org.dmfs.android.microfragments.transitions.Faded;
+import org.dmfs.android.microfragments.transitions.ForwardTransition;
+import org.dmfs.android.microfragments.transitions.FragmentTransition;
+import org.dmfs.httpessentials.exceptions.ProtocolError;
+import org.dmfs.httpessentials.exceptions.ProtocolException;
+import org.dmfs.rfc5545.DateTime;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+
+/**
+ * {@link MicroFragment} for the loading screen before showing the event list.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class EventListLoaderMicroFragment implements MicroFragment<Bundle>
+{
+    private final Bundle mArgs;
+
+
+    public EventListLoaderMicroFragment(Bundle args)
+    {
+        mArgs = args;
+    }
+
+
+    @NonNull
+    @Override
+    public String title(@NonNull Context context)
+    {
+        throw new UnsupportedOperationException("Title is not used for this fragment");
+    }
+
+
+    @NonNull
+    @Override
+    public Fragment fragment(@NonNull Context context, @NonNull MicroFragmentHost host)
+    {
+        return new LoaderFragment();
+    }
+
+
+    @NonNull
+    @Override
+    public Bundle parameter()
+    {
+        return mArgs;
+    }
+
+
+    @Override
+    public boolean skipOnBack()
+    {
+        return true;
+    }
+
+
+    @Override
+    public int describeContents()
+    {
+        return 0;
+    }
+
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags)
+    {
+        dest.writeBundle(mArgs);
+    }
+
+
+    public static final Creator<EventListLoaderMicroFragment> CREATOR = new Parcelable.Creator<EventListLoaderMicroFragment>()
+    {
+        @Override
+        public EventListLoaderMicroFragment createFromParcel(Parcel in)
+        {
+            return new EventListLoaderMicroFragment(in.readBundle(getClass().getClassLoader()));
+        }
+
+
+        @Override
+        public EventListLoaderMicroFragment[] newArray(int size)
+        {
+            return new EventListLoaderMicroFragment[size];
+        }
+    };
+
+
+    public static final class LoaderFragment extends BaseFragment
+    {
+        private final Timestamp mTimestamp = new UiTimestamp();
+
+        private SimpleServiceJobQueue<ApiService> mApiServiceJobQueue;
+
+
+        @Override
+        public void onCreate(@Nullable Bundle savedInstanceState)
+        {
+            super.onCreate(savedInstanceState);
+            mApiServiceJobQueue = new SimpleServiceJobQueue<>(new ApiService.FutureConnection(getActivity()));
+        }
+
+
+        @Nullable
+        @Override
+        public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
+        {
+            return inflater.inflate(R.layout.schedjoules_fragment_event_list_loader, container, false);
+        }
+
+
+        @Override
+        public void onResume()
+        {
+            super.onResume();
+            final Bundle incomingArgs = new FragmentEnvironment<Bundle>(this).microFragment().parameter();
+            DateTime startAfter = new OptionalArgument<>(Keys.DATE_TIME_START_AFTER, incomingArgs).value(DateTime.nowAndHere());
+            GeoLocation location = new SharedPrefLastSelectedPlace(getContext()).get().geoLocation();
+            final InitialEventsDiscovery query = new InitialEventsDiscovery(startAfter, location);
+
+            mApiServiceJobQueue.post(new ServiceJob<ApiService>()
+            {
+                @Override
+                public void execute(ApiService service)
+                {
+                    try
+                    {
+                        ResultPage<Envelope<Event>> resultPage = service.apiResponse(query);
+                        Bundle args = new BundleBuilder(incomingArgs).with(Keys.EVENTS_RESULT_PAGE, new EventResultPageBox(resultPage)).build();
+                        startTransition(new Faded(new ForwardTransition(new EventListMicroFragment(args), mTimestamp)));
+                    }
+                    catch (ProtocolError | IOException | ProtocolException | URISyntaxException | RuntimeException e)
+                    {
+                        onError();
+                    }
+                }
+
+
+                @Override
+                public void onTimeOut()
+                {
+                    onError();
+                }
+
+
+                private void onError()
+                {
+                    // TODO Show error msg on white background with '..tap to try again' and then start this splash again?
+                }
+            }, 5000);
+        }
+
+
+        @Override
+        public void onDestroy()
+        {
+            mApiServiceJobQueue.disconnect();
+            super.onDestroy();
+        }
+
+
+        private void startTransition(FragmentTransition fragmentTransition)
+        {
+            if (isResumed())
+            {
+                new FragmentEnvironment<>(this).host().execute(getActivity(), fragmentTransition);
+            }
+        }
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/controller/EventListController.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/controller/EventListController.java
@@ -19,13 +19,14 @@ package com.schedjoules.eventdiscovery.framework.eventlist.controller;
 
 import android.support.v7.widget.RecyclerView;
 
-import com.schedjoules.client.eventsdiscovery.GeoLocation;
+import com.schedjoules.client.ApiQuery;
+import com.schedjoules.client.eventsdiscovery.Envelope;
+import com.schedjoules.client.eventsdiscovery.Event;
+import com.schedjoules.client.eventsdiscovery.ResultPage;
 import com.schedjoules.eventdiscovery.framework.eventlist.view.EdgeReachScrollListener;
 import com.schedjoules.eventdiscovery.framework.eventlist.view.EventListBackgroundMessage;
 import com.schedjoules.eventdiscovery.framework.eventlist.view.EventListLoadingIndicatorOverlay;
 import com.schedjoules.eventdiscovery.framework.list.ListItems;
-
-import org.dmfs.rfc5545.DateTime;
 
 
 /**
@@ -40,7 +41,9 @@ public interface EventListController extends EdgeReachScrollListener.Listener
     /**
      * Initiate loading events for the given location and start time.
      */
-    void loadEvents(GeoLocation geoLocation, DateTime dateTime);
+    void loadEvents(ApiQuery<ResultPage<Envelope<Event>>> query);
+
+    void showEvents(ResultPage<Envelope<Event>> resultPage);
 
     void setAdapter(RecyclerView.Adapter adapter);
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/controller/EventListDownloadTask.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/controller/EventListDownloadTask.java
@@ -22,7 +22,6 @@ import android.os.AsyncTask;
 import com.schedjoules.client.ApiQuery;
 import com.schedjoules.client.eventsdiscovery.Envelope;
 import com.schedjoules.client.eventsdiscovery.Event;
-import com.schedjoules.client.eventsdiscovery.GeoLocation;
 import com.schedjoules.client.eventsdiscovery.ResultPage;
 import com.schedjoules.eventdiscovery.framework.async.DiscardCheck;
 import com.schedjoules.eventdiscovery.framework.async.DiscardingSafeAsyncTask;
@@ -80,14 +79,12 @@ public final class EventListDownloadTask extends
     {
 
         public final ApiQuery<ResultPage<Envelope<Event>>> mQuery;
-        public final GeoLocation mRequestLocation;
         public final ScrollDirection mDirection;
 
 
-        public TaskParam(GeoLocation requestLocation, ApiQuery<ResultPage<Envelope<Event>>> query, ScrollDirection direction)
+        public TaskParam(ApiQuery<ResultPage<Envelope<Event>>> query, ScrollDirection direction)
         {
             mQuery = query;
-            mRequestLocation = requestLocation;
             mDirection = direction;
         }
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/model/StructuredEnvelope.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/model/StructuredEnvelope.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.model;
+
+import com.schedjoules.client.eventsdiscovery.Envelope;
+
+
+/**
+ * {@link Envelope} which takes the ready properties as constructor parameters.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class StructuredEnvelope<T> implements Envelope<T>
+{
+    private final String mEtag;
+    private final String mUid;
+    private final boolean mHasPayload;
+    private final T mPayload;
+
+
+    public StructuredEnvelope(String etag, String uid, boolean hasPayload, T payload)
+    {
+        mEtag = etag;
+        mUid = uid;
+        mHasPayload = hasPayload;
+        mPayload = payload;
+    }
+
+
+    @Override
+    public String etag()
+    {
+        return mEtag;
+    }
+
+
+    @Override
+    public String uid()
+    {
+        return mUid;
+    }
+
+
+    @Override
+    public boolean hasPayload()
+    {
+        return mHasPayload;
+    }
+
+
+    @Override
+    public T payload()
+    {
+        return mPayload;
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/model/StructuredResultPage.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/model/StructuredResultPage.java
@@ -73,7 +73,7 @@ public final class StructuredResultPage<T> implements ResultPage<T>
     @Override
     public ApiQuery<ResultPage<T>> previousPageQuery() throws IllegalStateException
     {
-        if (mPrevPageQuery == null)
+        if (mIsFirstPage)
         {
             throw new IllegalStateException("No previous page query");
         }
@@ -84,7 +84,7 @@ public final class StructuredResultPage<T> implements ResultPage<T>
     @Override
     public ApiQuery<ResultPage<T>> nextPageQuery() throws IllegalStateException
     {
-        if (mNextPageQuery == null)
+        if (mIsLastPage)
         {
             throw new IllegalStateException("No next page query");
         }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/model/StructuredResultPage.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/model/StructuredResultPage.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.model;
+
+import android.support.annotation.Nullable;
+
+import com.schedjoules.client.ApiQuery;
+import com.schedjoules.client.eventsdiscovery.ResultPage;
+
+
+/**
+ * A {@link ResultPage} that takes the ready properties as constructor parameters.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class StructuredResultPage<T> implements ResultPage<T>
+{
+    private final Iterable<T> mItems;
+    private final boolean mIsFirstPage;
+    private final boolean mIsLastPage;
+    private final ApiQuery<ResultPage<T>> mPrevPageQuery;
+    private final ApiQuery<ResultPage<T>> mNextPageQuery;
+
+
+    public StructuredResultPage(Iterable<T> items, boolean isFirstPage, boolean isLastPage,
+                                @Nullable ApiQuery<ResultPage<T>> prevPageQuery,
+                                @Nullable ApiQuery<ResultPage<T>> nextPageQuery)
+    {
+        mItems = items;
+        mIsFirstPage = isFirstPage;
+        mIsLastPage = isLastPage;
+        mPrevPageQuery = prevPageQuery;
+        mNextPageQuery = nextPageQuery;
+    }
+
+
+    @Override
+    public Iterable<T> items()
+    {
+        return mItems;
+    }
+
+
+    @Override
+    public boolean isFirstPage()
+    {
+        return mIsFirstPage;
+    }
+
+
+    @Override
+    public boolean isLastPage()
+    {
+        return mIsLastPage;
+    }
+
+
+    @Override
+    public ApiQuery<ResultPage<T>> previousPageQuery() throws IllegalStateException
+    {
+        if (mPrevPageQuery == null)
+        {
+            throw new IllegalStateException("No previous page query");
+        }
+        return mPrevPageQuery;
+    }
+
+
+    @Override
+    public ApiQuery<ResultPage<T>> nextPageQuery() throws IllegalStateException
+    {
+        if (mNextPageQuery == null)
+        {
+            throw new IllegalStateException("No next page query");
+        }
+        return mNextPageQuery;
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/Keys.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/Keys.java
@@ -17,7 +17,10 @@
 
 package com.schedjoules.eventdiscovery.framework.serialization;
 
+import com.schedjoules.client.eventsdiscovery.Envelope;
+import com.schedjoules.client.eventsdiscovery.Event;
 import com.schedjoules.client.eventsdiscovery.GeoLocation;
+import com.schedjoules.client.eventsdiscovery.ResultPage;
 import com.schedjoules.eventdiscovery.framework.serialization.core.Key;
 
 import org.dmfs.android.microfragments.MicroFragment;
@@ -43,6 +46,8 @@ public final class Keys
     public static final Key<MicroFragment> MICRO_FRAGMENT = new SchedJoulesKey<>("MICRO_FRAGMENT");
 
     public static final Key<MicroFragmentHost> MICRO_FRAGMENT_HOST = new SchedJoulesKey<>("MICRO_FRAGMENT_HOST");
+
+    public static final Key<ResultPage<Envelope<Event>>> EVENTS_RESULT_PAGE = new SchedJoulesKey<>("EVENTS_RESULT_PAGE");
 
 
     private Keys()

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/EventEnvelopeBox.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/EventEnvelopeBox.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.serialization.boxes;
+
+import android.os.Parcel;
+
+import com.schedjoules.client.eventsdiscovery.Envelope;
+import com.schedjoules.client.eventsdiscovery.Event;
+import com.schedjoules.eventdiscovery.framework.model.StructuredEnvelope;
+import com.schedjoules.eventdiscovery.framework.serialization.core.Box;
+
+
+/**
+ * {@link Box} for {@link Envelope<Event>}
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class EventEnvelopeBox implements Box<Envelope<Event>>
+{
+    private final Envelope<Event> mEnvelope;
+
+
+    public EventEnvelopeBox(Envelope<Event> envelope)
+    {
+        mEnvelope = envelope;
+    }
+
+
+    @Override
+    public Envelope<Event> content()
+    {
+        return mEnvelope;
+    }
+
+
+    @Override
+    public int describeContents()
+    {
+        return 0;
+    }
+
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags)
+    {
+        dest.writeString(mEnvelope.etag());
+        dest.writeString(mEnvelope.uid());
+        dest.writeInt(mEnvelope.hasPayload() ? 1 : 0);
+        dest.writeParcelable(new EventBox(mEnvelope.payload()), flags);
+    }
+
+
+    public static final Creator<EventEnvelopeBox> CREATOR = new Creator<EventEnvelopeBox>()
+    {
+        @Override
+        public EventEnvelopeBox createFromParcel(Parcel in)
+        {
+            String etag = in.readString();
+            String uid = in.readString();
+            boolean hasPayload = in.readInt() == 1;
+            Box<Event> eventBox = in.readParcelable(getClass().getClassLoader());
+            return new EventEnvelopeBox(new StructuredEnvelope<>(etag, uid, hasPayload, eventBox.content()));
+        }
+
+
+        @Override
+        public EventEnvelopeBox[] newArray(int size)
+        {
+            return new EventEnvelopeBox[size];
+        }
+    };
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/EventEnvelopeBox.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/EventEnvelopeBox.java
@@ -61,7 +61,10 @@ public final class EventEnvelopeBox implements Box<Envelope<Event>>
         dest.writeString(mEnvelope.etag());
         dest.writeString(mEnvelope.uid());
         dest.writeInt(mEnvelope.hasPayload() ? 1 : 0);
-        dest.writeParcelable(new EventBox(mEnvelope.payload()), flags);
+        if (mEnvelope.hasPayload())
+        {
+            dest.writeParcelable(new EventBox(mEnvelope.payload()), flags);
+        }
     }
 
 
@@ -73,8 +76,8 @@ public final class EventEnvelopeBox implements Box<Envelope<Event>>
             String etag = in.readString();
             String uid = in.readString();
             boolean hasPayload = in.readInt() == 1;
-            Box<Event> eventBox = in.readParcelable(getClass().getClassLoader());
-            return new EventEnvelopeBox(new StructuredEnvelope<>(etag, uid, hasPayload, eventBox.content()));
+            Event event = hasPayload ? ((Box<Event>) in.readParcelable(getClass().getClassLoader())).content() : null;
+            return new EventEnvelopeBox(new StructuredEnvelope<>(etag, uid, hasPayload, event));
         }
 
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/EventEnvelopeBox.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/EventEnvelopeBox.java
@@ -68,7 +68,7 @@ public final class EventEnvelopeBox implements Box<Envelope<Event>>
     }
 
 
-    public static final Creator<EventEnvelopeBox> CREATOR = new Creator<EventEnvelopeBox>()
+    public static final Creator<Box<Envelope<Event>>> CREATOR = new Creator<Box<Envelope<Event>>>()
     {
         @Override
         public EventEnvelopeBox createFromParcel(Parcel in)

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/EventResultPageBox.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/EventResultPageBox.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.serialization.boxes;
+
+import android.os.Parcel;
+
+import com.schedjoules.client.ApiQuery;
+import com.schedjoules.client.State;
+import com.schedjoules.client.eventsdiscovery.Envelope;
+import com.schedjoules.client.eventsdiscovery.Event;
+import com.schedjoules.client.eventsdiscovery.ResultPage;
+import com.schedjoules.eventdiscovery.framework.model.StructuredResultPage;
+import com.schedjoules.eventdiscovery.framework.serialization.core.Box;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+
+/**
+ * {@link Box} for {@link ResultPage} with {@link Envelope} of {@link Event}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class EventResultPageBox implements Box<ResultPage<Envelope<Event>>>
+{
+    private final ResultPage<Envelope<Event>> mResultPage;
+
+
+    public EventResultPageBox(ResultPage<Envelope<Event>> resultPage)
+    {
+        mResultPage = resultPage;
+    }
+
+
+    @Override
+    public ResultPage<Envelope<Event>> content()
+    {
+        return mResultPage;
+    }
+
+
+    @Override
+    public int describeContents()
+    {
+        return 0;
+    }
+
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags)
+    {
+        Iterable<Envelope<Event>> envelopes = mResultPage.items();
+        List<Box<Envelope<Event>>> envelopeBoxes = new LinkedList<>();
+        for (Envelope<Event> envelope : envelopes)
+        {
+            envelopeBoxes.add(new EventEnvelopeBox(envelope));
+        }
+        dest.writeList(envelopeBoxes);
+
+        dest.writeInt(mResultPage.isFirstPage() ? 1 : 0);
+        dest.writeInt(mResultPage.isLastPage() ? 1 : 0);
+
+        if (!mResultPage.isFirstPage())
+        {
+            dest.writeSerializable(mResultPage.previousPageQuery().serializable());
+        }
+        if (!mResultPage.isLastPage())
+        {
+            dest.writeSerializable(mResultPage.nextPageQuery().serializable());
+        }
+    }
+
+
+    public static final Creator<EventResultPageBox> CREATOR = new Creator<EventResultPageBox>()
+    {
+        @Override
+        public EventResultPageBox createFromParcel(Parcel in)
+        {
+            List<Box<Envelope<Event>>> envelopeBoxes = new LinkedList<>();
+            in.readList(envelopeBoxes, getClass().getClassLoader());
+            List<Envelope<Event>> envelopes = new ArrayList<>();
+            for (Box<Envelope<Event>> envelopeBox : envelopeBoxes)
+            {
+                envelopes.add(envelopeBox.content());
+            }
+
+            boolean isFirstPage = in.readInt() == 1;
+            boolean isLastPage = in.readInt() == 1;
+
+            ApiQuery<ResultPage<Envelope<Event>>> prevQuery = null;
+            if (!isFirstPage)
+            {
+                prevQuery = ((State<ApiQuery<ResultPage<Envelope<Event>>>>) in.readSerializable()).restored();
+            }
+            ApiQuery<ResultPage<Envelope<Event>>> nextQuery = null;
+            if (!isLastPage)
+            {
+                nextQuery = ((State<ApiQuery<ResultPage<Envelope<Event>>>>) in.readSerializable()).restored();
+            }
+
+            return new EventResultPageBox(new StructuredResultPage(envelopes, isFirstPage, isLastPage, prevQuery, nextQuery));
+        }
+
+
+        @Override
+        public EventResultPageBox[] newArray(int size)
+        {
+            return new EventResultPageBox[size];
+        }
+    };
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/EventResultPageBox.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/EventResultPageBox.java
@@ -71,7 +71,7 @@ public final class EventResultPageBox implements Box<ResultPage<Envelope<Event>>
         {
             envelopeBoxes.add(new EventEnvelopeBox(envelope));
         }
-        dest.writeList(envelopeBoxes);
+        dest.writeTypedList(envelopeBoxes);
 
         dest.writeInt(mResultPage.isFirstPage() ? 1 : 0);
         dest.writeInt(mResultPage.isLastPage() ? 1 : 0);
@@ -93,7 +93,7 @@ public final class EventResultPageBox implements Box<ResultPage<Envelope<Event>>
         public EventResultPageBox createFromParcel(Parcel in)
         {
             List<Box<Envelope<Event>>> envelopeBoxes = new LinkedList<>();
-            in.readList(envelopeBoxes, getClass().getClassLoader());
+            in.readTypedList(envelopeBoxes, EventEnvelopeBox.CREATOR);
             List<Envelope<Event>> envelopes = new ArrayList<>();
             for (Box<Envelope<Event>> envelopeBox : envelopeBoxes)
             {

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list_loader.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list_loader.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
+            android:id="@+id/schedjoules_event_list_progress_bar"
+            android:layout_gravity="center"
+            android:layout_width="@dimen/schedjoules_event_list_progress_bar"
+            android:layout_height="@dimen/schedjoules_event_list_progress_bar"/>
+
+</FrameLayout>


### PR DESCRIPTION
---

This pull requests creates a loading MF for the List screen. It does not create loader fragment to  `EventListListFragment` yet, so that supports 2 ways of loading here, from initial parameters (needed after new city selected) and from `ResultPage`.

2 known issues:
- A second circle progress bar is shown for a moment after the loading, before showing the list. I don't know what is that, it should not be the one in the list layout. Probably no need to address that before switching to proper splash screen with the logo.
- Bundle is used as MF parameter, I would get back to those at the end of the refactors, to change them maybe to typed ones. In that case we need a that corresponds to EventDiscovery (SDK interface) 