### PR TITLE
Create Loader, Error, Show Fragments replacing EventListListFragment. #278

### DIFF
--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListFragment.java
@@ -110,11 +110,11 @@ public final class EventListFragment extends BaseFragment implements EventListMe
                     @Override
                     public void onPigeonReturn(@NonNull LoadResult<ResultPage<Envelope<Event>>> loadResult)
                     {
-                        if (loadResult.isSuccess())
+                        try
                         {
                             showResultPage(loadResult.result());
                         }
-                        else
+                        catch (Exception e)
                         {
                             mListFragmentContainer.replace(EventListListErrorFragment.newInstance(mReloadDovecote.cage()));
                         }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListFragment.java
@@ -47,6 +47,7 @@ import com.schedjoules.eventdiscovery.framework.utils.fragment.Add;
 import com.schedjoules.eventdiscovery.framework.utils.fragment.ChildFragmentContainer;
 import com.schedjoules.eventdiscovery.framework.utils.fragment.FragmentContainer;
 import com.schedjoules.eventdiscovery.framework.utils.loadresult.LoadResult;
+import com.schedjoules.eventdiscovery.framework.utils.loadresult.LoadResultException;
 
 import org.dmfs.android.microfragments.FragmentEnvironment;
 import org.dmfs.android.microfragments.utils.BooleanDovecote;
@@ -114,7 +115,7 @@ public final class EventListFragment extends BaseFragment implements EventListMe
                         {
                             showResultPage(loadResult.result());
                         }
-                        catch (Exception e)
+                        catch (LoadResultException e)
                         {
                             mListFragmentContainer.replace(EventListListErrorFragment.newInstance(mReloadDovecote.cage()));
                         }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListHeaderFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListHeaderFragment.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.eventlist;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.res.Resources;
+import android.databinding.DataBindingUtil;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v7.widget.Toolbar;
+import android.util.TypedValue;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.databinding.SchedjoulesFragmentEventListHeaderBinding;
+import com.schedjoules.eventdiscovery.framework.common.BaseActivity;
+import com.schedjoules.eventdiscovery.framework.common.BaseFragment;
+import com.schedjoules.eventdiscovery.framework.locationpicker.LocationPickerPlaceSelection;
+import com.schedjoules.eventdiscovery.framework.locationpicker.SharedPrefLastSelectedPlace;
+import com.schedjoules.eventdiscovery.framework.serialization.Keys;
+import com.schedjoules.eventdiscovery.framework.serialization.boxes.ParcelableBox;
+import com.schedjoules.eventdiscovery.framework.serialization.commons.Argument;
+import com.schedjoules.eventdiscovery.framework.serialization.commons.FragmentBuilder;
+import com.schedjoules.eventdiscovery.framework.widgets.TextWithIcon;
+
+import org.dmfs.pigeonpost.Cage;
+
+
+/**
+ * Fragment for the header (Toolbar and potentially filters) part of the Event List screen.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class EventListHeaderFragment extends BaseFragment
+{
+    private TextView mToolbarTitle;
+    private boolean mHasOnActivityResult;
+
+
+    public static Fragment newInstance(Cage<Boolean> reloadCage)
+    {
+        return new FragmentBuilder(new EventListHeaderFragment())
+                .with(Keys.RELOAD_EVENT_LIST_CAGE, new ParcelableBox<>(reloadCage))
+                .build();
+    }
+
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
+    {
+        SchedjoulesFragmentEventListHeaderBinding views = DataBindingUtil.inflate(inflater, R.layout.schedjoules_fragment_event_list_header, container, false);
+        setupToolbar(views);
+        return views.getRoot();
+    }
+
+
+    private void setupToolbar(SchedjoulesFragmentEventListHeaderBinding views)
+    {
+        Toolbar toolbar = views.schedjoulesEventListToolbar;
+        toolbar.setTitle(""); // Need to set it to empty, otherwise the activity label is set automatically
+
+        mToolbarTitle = views.schedjoulesEventListToolbarTitle;
+        mToolbarTitle.setOnClickListener(new View.OnClickListener()
+        {
+            @Override
+            public void onClick(View v)
+            {
+                new LocationPickerPlaceSelection().start(EventListHeaderFragment.this);
+            }
+        });
+
+        BaseActivity activity = (BaseActivity) getActivity();
+        activity.setSupportActionBar(toolbar);
+
+        Resources res = activity.getResources();
+        toolbar.setContentInsetsAbsolute(res.getDimensionPixelSize(R.dimen.schedjoules_list_item_padding_horizontal), toolbar.getContentInsetRight());
+
+        if (res.getBoolean(R.bool.schedjoules_enableBackArrowOnEventListScreen))
+        {
+            //noinspection ConstantConditions
+            activity.getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+
+        updateToolbarTitle();
+    }
+
+
+    private void updateToolbarTitle()
+    {
+        TypedValue typedValue = new TypedValue();
+        getActivity().getTheme().resolveAttribute(R.attr.schedjoules_dropdownArrow, typedValue, true);
+        mToolbarTitle.setText(new TextWithIcon(getContext(), new SharedPrefLastSelectedPlace(getContext()).get().namedPlace().name(), typedValue.resourceId));
+    }
+
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data)
+    {
+        mHasOnActivityResult = resultCode == Activity.RESULT_OK;
+    }
+
+
+    @Override
+    public void onResume()
+    {
+        super.onResume();
+        if (mHasOnActivityResult)
+        {
+            mHasOnActivityResult = false;
+            updateToolbarTitle();
+
+            new Argument<>(Keys.RELOAD_EVENT_LIST_CAGE, getArguments()).get().pigeon(true).send(getContext());
+        }
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListErrorFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListErrorFragment.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.eventlist;
+
+import android.databinding.DataBindingUtil;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.databinding.SchedjoulesFragmentEventListListErrorBinding;
+import com.schedjoules.eventdiscovery.framework.common.BaseFragment;
+import com.schedjoules.eventdiscovery.framework.serialization.Keys;
+import com.schedjoules.eventdiscovery.framework.serialization.boxes.ParcelableBox;
+import com.schedjoules.eventdiscovery.framework.serialization.commons.Argument;
+import com.schedjoules.eventdiscovery.framework.serialization.commons.FragmentBuilder;
+
+import org.dmfs.pigeonpost.Cage;
+
+
+/**
+ * Fragment to show after the event list failed to load. Contains and error message, and can be clicked to send a pigeon for retrying.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class EventListListErrorFragment extends BaseFragment
+{
+
+    public static Fragment newInstance(Cage<Boolean> retryCage)
+    {
+        return new FragmentBuilder(new EventListListErrorFragment())
+                .with(Keys.RETRY_EVENT_LIST_LOAD_CAGE, new ParcelableBox<>(retryCage))
+                .build();
+    }
+
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
+    {
+        SchedjoulesFragmentEventListListErrorBinding views =
+                DataBindingUtil.inflate(inflater, R.layout.schedjoules_fragment_event_list_list_error, container, false);
+
+        views.schedjoulesEventListBackgroundMessage.setText(R.string.schedjoules_event_list_error_bg_msg);
+
+        views.getRoot().setOnClickListener(new View.OnClickListener()
+        {
+            @Override
+            public void onClick(View v)
+            {
+                new Argument<>(Keys.RETRY_EVENT_LIST_LOAD_CAGE, getArguments()).get().pigeon(true).send(getContext());
+            }
+        });
+
+        return views.getRoot();
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListErrorFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListErrorFragment.java
@@ -44,10 +44,10 @@ import org.dmfs.pigeonpost.Cage;
 public final class EventListListErrorFragment extends BaseFragment
 {
 
-    public static Fragment newInstance(Cage<Boolean> retryCage)
+    public static Fragment newInstance(Cage<Boolean> reloadCage)
     {
         return new FragmentBuilder(new EventListListErrorFragment())
-                .with(Keys.RETRY_EVENT_LIST_LOAD_CAGE, new ParcelableBox<>(retryCage))
+                .with(Keys.RELOAD_EVENT_LIST_CAGE, new ParcelableBox<>(reloadCage))
                 .build();
     }
 
@@ -66,7 +66,7 @@ public final class EventListListErrorFragment extends BaseFragment
             @Override
             public void onClick(View v)
             {
-                new Argument<>(Keys.RETRY_EVENT_LIST_LOAD_CAGE, getArguments()).get().pigeon(true).send(getContext());
+                new Argument<>(Keys.RELOAD_EVENT_LIST_CAGE, getArguments()).get().pigeon(true).send(getContext());
             }
         });
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListLoaderFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListLoaderFragment.java
@@ -120,7 +120,7 @@ public final class EventListListLoaderFragment extends BaseFragment
                 }
                 catch (TimeoutException | InterruptedException | ProtocolError | IOException | ProtocolException | URISyntaxException e)
                 {
-                    loadResult = new ErrorResult<>();
+                    loadResult = new ErrorResult<>(e);
                 }
 
                 if (isResumed())

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListLoaderFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListLoaderFragment.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.eventlist;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.schedjoules.client.eventsdiscovery.Envelope;
+import com.schedjoules.client.eventsdiscovery.Event;
+import com.schedjoules.client.eventsdiscovery.GeoLocation;
+import com.schedjoules.client.eventsdiscovery.ResultPage;
+import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.common.BaseFragment;
+import com.schedjoules.eventdiscovery.framework.eventlist.controller.InitialEventsDiscovery;
+import com.schedjoules.eventdiscovery.framework.locationpicker.SharedPrefLastSelectedPlace;
+import com.schedjoules.eventdiscovery.framework.serialization.Keys;
+import com.schedjoules.eventdiscovery.framework.serialization.boxes.DateTimeBox;
+import com.schedjoules.eventdiscovery.framework.serialization.boxes.EventResultPageBox;
+import com.schedjoules.eventdiscovery.framework.serialization.boxes.ParcelableBox;
+import com.schedjoules.eventdiscovery.framework.serialization.commons.Argument;
+import com.schedjoules.eventdiscovery.framework.serialization.commons.BundleBuilder;
+import com.schedjoules.eventdiscovery.framework.serialization.commons.OptionalArgument;
+import com.schedjoules.eventdiscovery.framework.serialization.core.FluentBuilder;
+import com.schedjoules.eventdiscovery.framework.utils.loadresult.BoxResult;
+import com.schedjoules.eventdiscovery.framework.utils.loadresult.ErrorResult;
+import com.schedjoules.eventdiscovery.framework.utils.loadresult.LoadResult;
+import com.schedjoules.eventdiscovery.service.ApiService;
+
+import org.dmfs.httpessentials.exceptions.ProtocolError;
+import org.dmfs.httpessentials.exceptions.ProtocolException;
+import org.dmfs.optional.Optional;
+import org.dmfs.pigeonpost.Cage;
+import org.dmfs.rfc5545.DateTime;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.concurrent.TimeoutException;
+
+
+/**
+ * Fragment for loading the first event result page while showing a loading indicator.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class EventListListLoaderFragment extends BaseFragment
+{
+
+    private ApiService.FutureConnection mApiConnection;
+
+
+    public static Fragment newInstance(Optional<DateTime> start, Cage<LoadResult<ResultPage<Envelope<Event>>>> resultCage)
+    {
+        FluentBuilder<Bundle> bundleBuilder = new BundleBuilder()
+                .with(Keys.EVENTS_LOAD_RESULT_CAGE, new ParcelableBox<>(resultCage));
+        if (start.isPresent())
+        {
+            bundleBuilder = bundleBuilder.with(Keys.DATE_TIME_START_AFTER, new DateTimeBox(start.value()));
+        }
+        EventListListLoaderFragment fragment = new EventListListLoaderFragment();
+        fragment.setArguments(bundleBuilder.build());
+        return fragment;
+    }
+
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+        mApiConnection = new ApiService.FutureConnection(getActivity());
+    }
+
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
+    {
+        return inflater.inflate(R.layout.schedjoules_fragment_event_list_list_loader, container, false);
+    }
+
+
+    @Override
+    public void onResume()
+    {
+        super.onResume();
+
+        new Thread(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                DateTime startAfter = new OptionalArgument<>(Keys.DATE_TIME_START_AFTER, EventListListLoaderFragment.this)
+                        .value(DateTime.nowAndHere());
+                GeoLocation location = new SharedPrefLastSelectedPlace(getContext()).get().geoLocation();
+                InitialEventsDiscovery query = new InitialEventsDiscovery(startAfter, location);
+
+                LoadResult<ResultPage<Envelope<Event>>> loadResult;
+                try
+                {
+                    ResultPage<Envelope<Event>> resultPage = mApiConnection.service(5000).apiResponse(query);
+                    loadResult = new BoxResult<>(new EventResultPageBox(resultPage));
+                }
+                catch (TimeoutException | InterruptedException | ProtocolError | IOException | ProtocolException | URISyntaxException e)
+                {
+                    loadResult = new ErrorResult<>();
+                }
+
+                if (isResumed())
+                {
+                    new Argument<>(Keys.EVENTS_LOAD_RESULT_CAGE, getArguments()).get().pigeon(loadResult).send(getActivity());
+                }
+            }
+        }).start();
+    }
+
+
+    @Override
+    public void onDestroy()
+    {
+        mApiConnection.disconnect();
+        super.onDestroy();
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListNoEventsFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListNoEventsFragment.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.eventlist;
+
+import android.databinding.DataBindingUtil;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.databinding.SchedjoulesFragmentEventListListErrorBinding;
+import com.schedjoules.eventdiscovery.framework.common.BaseFragment;
+
+
+/**
+ * Fragment for showing a background message that no event was found.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class EventListListNoEventsFragment extends BaseFragment
+{
+    public static Fragment newInstance()
+    {
+        return new EventListListNoEventsFragment();
+    }
+
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
+    {
+        SchedjoulesFragmentEventListListErrorBinding views =
+                DataBindingUtil.inflate(inflater, R.layout.schedjoules_fragment_event_list_list_error, container, false);
+
+        views.schedjoulesEventListBackgroundMessage.setText(R.string.schedjoules_event_list_no_events_found);
+
+        return views.getRoot();
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/controller/EventListController.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/controller/EventListController.java
@@ -19,36 +19,21 @@ package com.schedjoules.eventdiscovery.framework.eventlist.controller;
 
 import android.support.v7.widget.RecyclerView;
 
-import com.schedjoules.client.ApiQuery;
 import com.schedjoules.client.eventsdiscovery.Envelope;
 import com.schedjoules.client.eventsdiscovery.Event;
 import com.schedjoules.client.eventsdiscovery.ResultPage;
 import com.schedjoules.eventdiscovery.framework.eventlist.view.EdgeReachScrollListener;
-import com.schedjoules.eventdiscovery.framework.eventlist.view.EventListBackgroundMessage;
-import com.schedjoules.eventdiscovery.framework.eventlist.view.EventListLoadingIndicatorOverlay;
-import com.schedjoules.eventdiscovery.framework.list.ListItems;
 
 
 /**
- * Controller for the event list, it responsible to initiate API request, manage states and update the {@link ListItems} associated with the {@link
- * RecyclerView}
+ * Controller for the event list, loads further pages, manages states, updates the {@link RecyclerView}.
  *
  * @author Gabor Keszthelyi
  */
 public interface EventListController extends EdgeReachScrollListener.Listener
 {
-
-    /**
-     * Initiate loading events for the given location and start time.
-     */
-    void loadEvents(ApiQuery<ResultPage<Envelope<Event>>> query);
-
     void showEvents(ResultPage<Envelope<Event>> resultPage);
 
     void setAdapter(RecyclerView.Adapter adapter);
-
-    void setBackgroundMessageUI(EventListBackgroundMessage backgroundMessage);
-
-    void setLoadingIndicatorUI(EventListLoadingIndicatorOverlay loadingIndicatorOverlay);
 
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/controller/EventListControllerImpl.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/controller/EventListControllerImpl.java
@@ -28,8 +28,6 @@ import com.schedjoules.client.eventsdiscovery.ResultPage;
 import com.schedjoules.eventdiscovery.framework.async.SafeAsyncTaskResult;
 import com.schedjoules.eventdiscovery.framework.eventlist.controller.EventListDownloadTask.TaskParam;
 import com.schedjoules.eventdiscovery.framework.eventlist.controller.EventListDownloadTask.TaskResult;
-import com.schedjoules.eventdiscovery.framework.eventlist.view.EventListBackgroundMessage;
-import com.schedjoules.eventdiscovery.framework.eventlist.view.EventListLoadingIndicatorOverlay;
 import com.schedjoules.eventdiscovery.framework.utils.FutureServiceConnection;
 import com.schedjoules.eventdiscovery.service.ApiService;
 
@@ -51,7 +49,7 @@ import static com.schedjoules.eventdiscovery.framework.eventlist.controller.Scro
  *
  * @author Gabor Keszthelyi
  */
-public final class EventListControllerImpl implements EventListController, EventListBackgroundMessage.OnClickListener
+public final class EventListControllerImpl implements EventListController
 {
     public static final int CLOSE_TO_TOP_OR_BOTTOM_THRESHOLD = 30;
 
@@ -62,8 +60,6 @@ public final class EventListControllerImpl implements EventListController, Event
     private final ExecutorService mExecutorService;
     private final EventListItems<IFlexible, FlexibleAdapter<IFlexible>> mItems;
     private final EnumMap<ScrollDirection, ResultPage<Envelope<Event>>> mLastResultPages;
-    private EventListBackgroundMessage mBackgroundMessage;
-    private EventListLoadingIndicatorOverlay mLoadingIndicatorOverlay;
     private Map<ScrollDirection, Boolean> mIsLoading;
 
     private DownloadTaskClient mDownloadTaskClient;
@@ -93,13 +89,6 @@ public final class EventListControllerImpl implements EventListController, Event
 
 
     @Override
-    public void loadEvents(ApiQuery<ResultPage<Envelope<Event>>> query)
-    {
-        queueDownloadTask(query, BOTTOM);
-    }
-
-
-    @Override
     public void showEvents(ResultPage<Envelope<Event>> resultPage)
     {
         new ComposeListAndShowTask(resultPage).executeOnExecutor(mExecutorService);
@@ -113,27 +102,12 @@ public final class EventListControllerImpl implements EventListController, Event
     }
 
 
-    @Override
-    public void setBackgroundMessageUI(EventListBackgroundMessage backgroundMessage)
-    {
-        mBackgroundMessage = backgroundMessage;
-        mBackgroundMessage.setOnClickListener(this);
-    }
-
-
-    @Override
-    public void setLoadingIndicatorUI(EventListLoadingIndicatorOverlay loadingIndicatorOverlay)
-    {
-        mLoadingIndicatorOverlay = loadingIndicatorOverlay;
-    }
-
-
     private void queueDownloadTask(ApiQuery<ResultPage<Envelope<Event>>> query, ScrollDirection scrollDirection)
     {
         //noinspection unchecked
         new EventListDownloadTask(new TaskParam(query, scrollDirection), mDownloadTaskClient)
                 .executeOnExecutor(mExecutorService, mApiService);
-        markLoadStarted(mItems.isEmpty(), scrollDirection);
+        markLoadStarted(scrollDirection);
     }
 
 
@@ -141,7 +115,7 @@ public final class EventListControllerImpl implements EventListController, Event
     {
         //noinspection unchecked
         new EventListDownloadTask(taskParam, mDownloadTaskClient).executeOnExecutor(mExecutorService, mApiService);
-        markLoadStarted(mItems.isEmpty(), taskParam.mDirection);
+        markLoadStarted(taskParam.mDirection);
     }
 
 
@@ -151,13 +125,6 @@ public final class EventListControllerImpl implements EventListController, Event
         {
             queueDownloadTask(direction.comingPageQuery(mLastResultPages), direction);
         }
-    }
-
-
-    @Override
-    public void onBackgroundMessageClick()
-    {
-        onScrolledCloseToEdge(BOTTOM);
     }
 
 
@@ -178,59 +145,31 @@ public final class EventListControllerImpl implements EventListController, Event
     }
 
 
-    private void markLoadStarted(boolean isEmpty, ScrollDirection direction)
+    private void markLoadStarted(ScrollDirection direction)
     {
         mIsLoading.put(direction, true);
-        if (isEmpty)
+        // This request will result in empty first page, so not worth showing the loading
+        if (!(direction == TOP && mItems.isTodayShown()))
         {
-            mLoadingIndicatorOverlay.show();
-        }
-        else
-        {
-            // This request will result in empty first page, so not worth showing the loading
-            if (!(direction == TOP && mItems.isTodayShown()))
-            {
-                mItems.addSpecialItemPost(direction.loadingIndicatorItem(), direction);
-            }
+            mItems.addSpecialItemPost(direction.loadingIndicatorItem(), direction);
         }
     }
 
 
-    private void markLoadFinishedSuccess(boolean isEmptyBefore, boolean isEmptyAfter, ScrollDirection direction)
+    private void markLoadFinishedSuccess(ScrollDirection direction)
     {
         mIsLoading.put(direction, false);
 
-        // Hide loading:
-        if (isEmptyBefore)
-        {
-            mLoadingIndicatorOverlay.hide();
-            mBackgroundMessage.hide();
-        }
-        else
-        {
-            mItems.removeSpecialItem(direction.loadingIndicatorItem(), direction);
-        }
+        mItems.removeSpecialItem(direction.loadingIndicatorItem(), direction);
 
         // Resuming from error mode:
         if (mIsInErrorMode.get(direction))
         {
-            if (isEmptyBefore)
-            {
-                mBackgroundMessage.hide();
-            }
-            else
-            {
-                mItems.removeSpecialItem(direction.errorItem(), direction);
-            }
+            mItems.removeSpecialItem(direction.errorItem(), direction);
             mIsInErrorMode.put(direction, false);
         }
 
-        // No more events message:
-        if (isEmptyAfter)
-        {
-            mBackgroundMessage.showNoEventsFoundMsg();
-        }
-        else if (!direction.hasComingPageQuery(mLastResultPages)
+        if (!direction.hasComingPageQuery(mLastResultPages)
                 && (direction == BOTTOM || (direction == TOP && !mItems.isTodayShown())))
         {
             mItems.addSpecialItemNow(direction.noMoreEventsItem(), direction);
@@ -238,30 +177,15 @@ public final class EventListControllerImpl implements EventListController, Event
     }
 
 
-    private void markLoadFinishedError(boolean isEmpty, ScrollDirection direction)
+    private void markLoadFinishedError(ScrollDirection direction)
     {
         mIsLoading.put(direction, false);
 
-        // Hide loading indicator:
-        if (isEmpty)
-        {
-            mLoadingIndicatorOverlay.hide();
-        }
-        else
-        {
-            mItems.removeSpecialItem(direction.loadingIndicatorItem(), direction);
-        }
+        mItems.removeSpecialItem(direction.loadingIndicatorItem(), direction);
 
         if (!mIsInErrorMode.get(direction))
         {
-            if (isEmpty)
-            {
-                mBackgroundMessage.showErrorMsg();
-            }
-            else
-            {
-                mItems.addSpecialItemNow(direction.errorItem(), direction);
-            }
+            mItems.addSpecialItemNow(direction.errorItem(), direction);
             mIsInErrorMode.put(direction, true);
         }
     }
@@ -297,10 +221,9 @@ public final class EventListControllerImpl implements EventListController, Event
         {
             mLastResultPages.put(taskParam.mDirection, result.mResultPage);
 
-            boolean isEmptyBefore = mItems.isEmpty();
             mItems.mergeNewItems(result.mListItems, taskParam.mDirection);
 
-            markLoadFinishedSuccess(isEmptyBefore, mItems.isEmpty(), taskParam.mDirection);
+            markLoadFinishedSuccess(taskParam.mDirection);
 
             if (taskParam.mQuery instanceof InitialEventsDiscovery)
             {
@@ -314,7 +237,7 @@ public final class EventListControllerImpl implements EventListController, Event
         {
             mErrorTaskParam.put(taskParam.mDirection, taskParam);
             Log.e(TAG, "Error during download task", e);
-            markLoadFinishedError(mItems.isEmpty(), taskParam.mDirection);
+            markLoadFinishedError(taskParam.mDirection);
         }
     }
 
@@ -342,10 +265,11 @@ public final class EventListControllerImpl implements EventListController, Event
         {
             mLastResultPages.put(BOTTOM, mResultPage);
             mItems.mergeNewItems(listItems, BOTTOM);
-            markLoadFinishedSuccess(true, mItems.isEmpty(), BOTTOM);
+            markLoadFinishedSuccess(BOTTOM);
 
             mLastResultPages.put(TOP, mResultPage);
             queueComingPage(TOP);
         }
     }
+
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/Keys.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/Keys.java
@@ -53,7 +53,8 @@ public final class Keys
 
     public static final Key<Cage<LoadResult<ResultPage<Envelope<Event>>>>> EVENTS_LOAD_RESULT_CAGE = new SchedJoulesKey<>("EVENTS_LOAD_RESULT_CAGE");
 
-    public static final Key<Cage<Boolean>> RETRY_EVENT_LIST_LOAD_CAGE = new SchedJoulesKey<>("RETRY_EVENT_LIST_LOAD_CAGE");
+    public static final Key<Cage<Boolean>> RELOAD_EVENT_LIST_CAGE = new SchedJoulesKey<>("RELOAD_EVENT_LIST_CAGE");
+
 
     private Keys()
     {

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/Keys.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/Keys.java
@@ -22,9 +22,11 @@ import com.schedjoules.client.eventsdiscovery.Event;
 import com.schedjoules.client.eventsdiscovery.GeoLocation;
 import com.schedjoules.client.eventsdiscovery.ResultPage;
 import com.schedjoules.eventdiscovery.framework.serialization.core.Key;
+import com.schedjoules.eventdiscovery.framework.utils.loadresult.LoadResult;
 
 import org.dmfs.android.microfragments.MicroFragment;
 import org.dmfs.android.microfragments.MicroFragmentHost;
+import org.dmfs.pigeonpost.Cage;
 import org.dmfs.rfc5545.DateTime;
 
 
@@ -49,6 +51,9 @@ public final class Keys
 
     public static final Key<ResultPage<Envelope<Event>>> EVENTS_RESULT_PAGE = new SchedJoulesKey<>("EVENTS_RESULT_PAGE");
 
+    public static final Key<Cage<LoadResult<ResultPage<Envelope<Event>>>>> EVENTS_LOAD_RESULT_CAGE = new SchedJoulesKey<>("EVENTS_LOAD_RESULT_CAGE");
+
+    public static final Key<Cage<Boolean>> RETRY_EVENT_LIST_LOAD_CAGE = new SchedJoulesKey<>("RETRY_EVENT_LIST_LOAD_CAGE");
 
     private Keys()
     {

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/commons/FragmentBuilder.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/commons/FragmentBuilder.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.serialization.commons;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+
+import com.schedjoules.eventdiscovery.framework.serialization.core.Box;
+import com.schedjoules.eventdiscovery.framework.serialization.core.Boxable;
+import com.schedjoules.eventdiscovery.framework.serialization.core.FluentBuilder;
+import com.schedjoules.eventdiscovery.framework.serialization.core.Key;
+
+import org.dmfs.optional.Optional;
+
+
+/**
+ * Convenience {@link FluentBuilder} for creating {@link Fragment} with args.
+ * <p>
+ * Note: Not immutable, the same Fragment instance is returned with {@link #build()} as received in the constructor.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class FragmentBuilder implements FluentBuilder<Fragment>
+{
+    private final Fragment mFragment;
+    private final FluentBuilder<Bundle> mBundleBuilder;
+
+
+    public FragmentBuilder(Fragment fragment)
+    {
+        this(fragment, new BundleBuilder());
+    }
+
+
+    private FragmentBuilder(Fragment fragment, FluentBuilder<Bundle> bundleBuilder)
+    {
+        mFragment = fragment;
+        mBundleBuilder = bundleBuilder;
+    }
+
+
+    @Override
+    public Fragment build()
+    {
+        mFragment.setArguments(mBundleBuilder.build());
+        return mFragment;
+    }
+
+
+    @Override
+    public <T> FluentBuilder<Fragment> with(Key<T> key, Box<T> box)
+    {
+        return new FragmentBuilder(mFragment, mBundleBuilder.with(key, box));
+    }
+
+
+    @Override
+    public <T> FluentBuilder<Fragment> with(Key<T> key, Optional<Box<T>> optBox)
+    {
+        return new FragmentBuilder(mFragment, mBundleBuilder.with(key, optBox));
+    }
+
+
+    @Override
+    public <T extends Boxable> FluentBuilder<Fragment> withBoxable(Key<T> key, Optional<T> optBoxable)
+    {
+        return new FragmentBuilder(mFragment, mBundleBuilder.withBoxable(key, optBoxable));
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/dovecote/BoxCage.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/dovecote/BoxCage.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.dovecote;
+
+import android.content.Context;
+import android.os.Parcel;
+import android.support.annotation.NonNull;
+import android.support.v4.content.LocalBroadcastManager;
+
+import com.schedjoules.eventdiscovery.framework.serialization.commons.IntentBuilder;
+import com.schedjoules.eventdiscovery.framework.serialization.commons.StringKey;
+import com.schedjoules.eventdiscovery.framework.serialization.core.Box;
+import com.schedjoules.eventdiscovery.framework.serialization.core.Key;
+
+import org.dmfs.pigeonpost.Cage;
+import org.dmfs.pigeonpost.Pigeon;
+
+
+/**
+ * A {@link Cage} to send {@link Box} objects corresponding to a {@link Key} via a {@link LocalBroadcastManager}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class BoxCage<T> implements Cage<Box<T>>
+{
+    private final Key<T> mKey;
+
+
+    public BoxCage(Key<T> key)
+    {
+        mKey = key;
+    }
+
+
+    @NonNull
+    @Override
+    public Pigeon<Box<T>> pigeon(@NonNull final Box<T> box)
+    {
+        return new Pigeon<Box<T>>()
+        {
+            @Override
+            public void send(@NonNull Context context)
+            {
+                LocalBroadcastManager.getInstance(context)
+                        .sendBroadcastSync(new IntentBuilder(mKey.name()).with(mKey, box).build());
+            }
+        };
+    }
+
+
+    @Override
+    public int describeContents()
+    {
+        return 0;
+    }
+
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags)
+    {
+        dest.writeString(mKey.name());
+    }
+
+
+    public static final Creator<BoxCage> CREATOR = new Creator<BoxCage>()
+    {
+        @Override
+        public BoxCage createFromParcel(Parcel in)
+        {
+            return new BoxCage(new StringKey<>(in.readString()));
+        }
+
+
+        @Override
+        public BoxCage[] newArray(int size)
+        {
+            return new BoxCage[size];
+        }
+    };
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/dovecote/BoxDovecote.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/dovecote/BoxDovecote.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.dovecote;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.support.annotation.NonNull;
+import android.support.v4.content.LocalBroadcastManager;
+
+import com.schedjoules.eventdiscovery.framework.serialization.commons.Argument;
+import com.schedjoules.eventdiscovery.framework.serialization.core.Box;
+import com.schedjoules.eventdiscovery.framework.serialization.core.Key;
+
+import org.dmfs.pigeonpost.Cage;
+import org.dmfs.pigeonpost.Dovecote;
+import org.dmfs.pigeonpost.Pigeon;
+import org.dmfs.pigeonpost.localbroadcast.tools.MainThreadExecutor;
+
+
+/**
+ * A {@link Dovecote} that receives {@link Pigeon} with a {@link LocalBroadcastManager}.
+ * <p>
+ * The {@link Pigeon} payload can be a {@link Box} corresponding to a {@link Key}, the {@link Box}'s content will be delivered in the callback.
+ * <p>
+ * {@link BoxCage}s are good for communication within the same process. Note that sent {@link Pigeon}s are lost if there are no active {@link
+ * BoxDovecote}s available listening for the same {@link Key}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class BoxDovecote<T> implements Dovecote<Box<T>>
+{
+    private final Context mContext;
+    private final Key<T> mKey;
+    private final BroadcastReceiver mReceiver;
+
+
+    public BoxDovecote(@NonNull Context context, @NonNull Key<T> key, @NonNull OnPigeonReturnCallback<T> callback)
+    {
+        mContext = context;
+        mKey = key;
+        mReceiver = new BoxDovecoteReceiver<>(callback, key);
+        LocalBroadcastManager.getInstance(context).registerReceiver(mReceiver, new IntentFilter(key.name()));
+    }
+
+
+    @NonNull
+    @Override
+    public Cage<Box<T>> cage()
+    {
+        return new BoxCage<T>(mKey);
+    }
+
+
+    @Override
+    public void dispose()
+    {
+        LocalBroadcastManager.getInstance(mContext).unregisterReceiver(mReceiver);
+    }
+
+
+    private static final class BoxDovecoteReceiver<T> extends BroadcastReceiver
+    {
+        private final Dovecote.OnPigeonReturnCallback<T> mCallback;
+        private final Key<T> mKey;
+
+
+        public BoxDovecoteReceiver(@NonNull Dovecote.OnPigeonReturnCallback<T> callback, Key<T> key)
+        {
+            mCallback = callback;
+            mKey = key;
+        }
+
+
+        @Override
+        public void onReceive(Context context, final Intent intent)
+        {
+            MainThreadExecutor.INSTANCE.execute(new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    mCallback.onPigeonReturn(new Argument<>(mKey, intent).get());
+                }
+            });
+        }
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/fragment/Add.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/fragment/Add.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.fragment;
+
+import android.support.annotation.IdRes;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+
+
+/**
+ * {@link FragmentTransaction} to add a {@link Fragment}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class Add implements FragmentTransaction
+{
+    private final int mContainerResId;
+    private final Fragment mFragment;
+
+
+    public Add(@IdRes int containerResId, Fragment fragment)
+    {
+        mContainerResId = containerResId;
+        mFragment = fragment;
+    }
+
+
+    @Override
+    public void commit(FragmentActivity activity)
+    {
+        doCommit(activity.getSupportFragmentManager());
+    }
+
+
+    @Override
+    public void commit(Fragment fragment)
+    {
+        doCommit(fragment.getChildFragmentManager());
+    }
+
+
+    private void doCommit(FragmentManager fm)
+    {
+        fm.beginTransaction().add(mContainerResId, mFragment).commit();
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/fragment/ChildFragmentContainer.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/fragment/ChildFragmentContainer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.fragment;
+
+import android.support.v4.app.Fragment;
+
+
+/**
+ * {@link FragmentContainer} for a child Fragment in a parent Fragment.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class ChildFragmentContainer implements FragmentContainer
+{
+    private final Fragment mParentFragment;
+    private final int mContainerResId;
+
+
+    public ChildFragmentContainer(Fragment parentFragment, int containerResId)
+    {
+        mParentFragment = parentFragment;
+        mContainerResId = containerResId;
+    }
+
+
+    @Override
+    public void add(Fragment fragment)
+    {
+        new Add(mContainerResId, fragment).commit(mParentFragment);
+    }
+
+
+    @Override
+    public void replace(Fragment fragment)
+    {
+        new Replace(mContainerResId, fragment).commit(mParentFragment);
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/fragment/FragmentContainer.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/fragment/FragmentContainer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.fragment;
+
+import android.support.v4.app.Fragment;
+
+
+/**
+ * Represents a concrete Fragment container in a layout where a Fragment can be added or replaced.
+ *
+ * @author Gabor Keszthelyi
+ */
+public interface FragmentContainer
+{
+
+    /**
+     * Adds the given fragment to this container 'location'.
+     */
+    void add(Fragment fragment);
+
+    /**
+     * Replaces the Fragment already in the container with the given one.
+     */
+    void replace(Fragment fragment);
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/fragment/FragmentTransaction.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/fragment/FragmentTransaction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.fragment;
+
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+
+
+/**
+ * Represents a standard Fragment transaction.
+ *
+ * @author Gabor Keszthelyi
+ */
+public interface FragmentTransaction
+{
+    /**
+     * Commit the transaction using {@link FragmentActivity#getSupportFragmentManager()}.
+     */
+    void commit(FragmentActivity activity);
+
+    /**
+     * Commit the transaction using {@link Fragment#getChildFragmentManager()}.
+     */
+    void commit(Fragment fragment);
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/fragment/Replace.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/fragment/Replace.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.fragment;
+
+import android.support.annotation.IdRes;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+
+
+/**
+ * {@link FragmentTransaction} to replace a {@link Fragment}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class Replace implements FragmentTransaction
+{
+    private final int mContainerResId;
+    private final Fragment mFragment;
+
+
+    public Replace(@IdRes int containerResId, Fragment fragment)
+    {
+        mContainerResId = containerResId;
+        mFragment = fragment;
+    }
+
+
+    @Override
+    public void commit(FragmentActivity activity)
+    {
+        doCommit(activity.getSupportFragmentManager());
+    }
+
+
+    @Override
+    public void commit(Fragment fragment)
+    {
+        doCommit(fragment.getChildFragmentManager());
+    }
+
+
+    private void doCommit(FragmentManager fm)
+    {
+        fm.beginTransaction().replace(mContainerResId, mFragment).commit();
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/BoxResult.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/BoxResult.java
@@ -39,13 +39,6 @@ public final class BoxResult<T> implements LoadResult<T>
 
 
     @Override
-    public boolean isSuccess()
-    {
-        return true;
-    }
-
-
-    @Override
     public T result() throws IllegalStateException
     {
         return mBox.content();

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/BoxResult.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/BoxResult.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.loadresult;
+
+import android.os.Parcel;
+
+import com.schedjoules.eventdiscovery.framework.serialization.core.Box;
+
+
+/**
+ * A successful {@link LoadResult} that can take a {@link Box} and use it's content as result value.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class BoxResult<T> implements LoadResult<T>
+{
+    private final Box<T> mBox;
+
+
+    public BoxResult(Box<T> box)
+    {
+        mBox = box;
+    }
+
+
+    @Override
+    public boolean isSuccess()
+    {
+        return true;
+    }
+
+
+    @Override
+    public T result() throws IllegalStateException
+    {
+        return mBox.content();
+    }
+
+
+    @Override
+    public int describeContents()
+    {
+        return 0;
+    }
+
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags)
+    {
+        dest.writeParcelable(mBox, flags);
+    }
+
+
+    public static final Creator<BoxResult> CREATOR = new Creator<BoxResult>()
+    {
+        @Override
+        public BoxResult createFromParcel(Parcel in)
+        {
+            return new BoxResult((Box) in.readParcelable(getClass().getClassLoader()));
+        }
+
+
+        @Override
+        public BoxResult[] newArray(int size)
+        {
+            return new BoxResult[size];
+        }
+    };
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/ErrorResult.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/ErrorResult.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.loadresult;
+
+import android.os.Parcel;
+
+
+/**
+ * Error {@link LoadResult}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class ErrorResult<T> implements LoadResult<T>
+{
+    @Override
+    public boolean isSuccess()
+    {
+        return false;
+    }
+
+
+    @Override
+    public T result() throws IllegalStateException
+    {
+        throw new IllegalStateException("Error result has no result");
+    }
+
+
+    @Override
+    public int describeContents()
+    {
+        return 0;
+    }
+
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags)
+    {
+
+    }
+
+
+    public static final Creator<ErrorResult> CREATOR = new Creator<ErrorResult>()
+    {
+        @Override
+        public ErrorResult createFromParcel(Parcel in)
+        {
+            return new ErrorResult();
+        }
+
+
+        @Override
+        public ErrorResult[] newArray(int size)
+        {
+            return new ErrorResult[size];
+        }
+    };
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/ErrorResult.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/ErrorResult.java
@@ -27,17 +27,19 @@ import android.os.Parcel;
  */
 public final class ErrorResult<T> implements LoadResult<T>
 {
-    @Override
-    public boolean isSuccess()
+    private final Exception mCauseException;
+
+
+    public ErrorResult(Exception causeException)
     {
-        return false;
+        mCauseException = causeException;
     }
 
 
     @Override
-    public T result() throws IllegalStateException
+    public T result() throws Exception
     {
-        throw new IllegalStateException("Error result has no result");
+        throw new LoadResultException(mCauseException);
     }
 
 
@@ -51,7 +53,7 @@ public final class ErrorResult<T> implements LoadResult<T>
     @Override
     public void writeToParcel(Parcel dest, int flags)
     {
-
+        dest.writeSerializable(mCauseException);
     }
 
 
@@ -60,7 +62,7 @@ public final class ErrorResult<T> implements LoadResult<T>
         @Override
         public ErrorResult createFromParcel(Parcel in)
         {
-            return new ErrorResult();
+            return new ErrorResult((Exception) in.readSerializable());
         }
 
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/ErrorResult.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/ErrorResult.java
@@ -37,7 +37,7 @@ public final class ErrorResult<T> implements LoadResult<T>
 
 
     @Override
-    public T result() throws Exception
+    public T result() throws LoadResultException
     {
         throw new LoadResultException(mCauseException);
     }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/LoadResult.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/LoadResult.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.loadresult;
+
+import android.os.Parcelable;
+
+
+/**
+ * The result of a loading operation.
+ *
+ * @author Gabor Keszthelyi
+ */
+public interface LoadResult<T> extends Parcelable
+{
+    /**
+     * Tells whether the loading was successful, i.e. if there is a result.
+     */
+    boolean isSuccess();
+
+    /**
+     * Returns the success result. Should call {@link #isSuccess()} first.
+     *
+     * @throws IllegalStateException
+     *         if the load was not successful
+     */
+    T result() throws IllegalStateException;
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/LoadResult.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/LoadResult.java
@@ -30,8 +30,8 @@ public interface LoadResult<T> extends Parcelable
     /**
      * Returns the load result.
      *
-     * @throws Exception
-     *         if the load was not successful
+     * @throws LoadResultException
+     *         if the load was not successful (with the cause as the original exception at the point of failure)
      */
-    T result() throws Exception;
+    T result() throws LoadResultException;
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/LoadResultException.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/loadresult/LoadResultException.java
@@ -17,21 +17,16 @@
 
 package com.schedjoules.eventdiscovery.framework.utils.loadresult;
 
-import android.os.Parcelable;
-
-
 /**
- * The result of a loading operation.
+ * A {@link Exception} signalling that a load failed, with the cause as the original exception throw at the point of failure.
+ * Used by {@link LoadResult}.
  *
  * @author Gabor Keszthelyi
  */
-public interface LoadResult<T> extends Parcelable
+public final class LoadResultException extends Exception
 {
-    /**
-     * Returns the load result.
-     *
-     * @throws Exception
-     *         if the load was not successful
-     */
-    T result() throws Exception;
+    public LoadResultException(Throwable cause)
+    {
+        super("Load failed", cause);
+    }
 }

--- a/eventdiscovery-sdk/src/main/res/layout-v21/schedjoules_fragment_event_list.xml
+++ b/eventdiscovery-sdk/src/main/res/layout-v21/schedjoules_fragment_event_list.xml
@@ -14,31 +14,20 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
-            <android.support.v7.widget.Toolbar
-                    android:id="@+id/schedjoules_event_list_toolbar"
+            <FrameLayout
+                    android:id="@+id/schedjoules_event_list_header_container"
                     android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize">
-
-                <TextView
-                        android:id="@+id/schedjoules_event_list_toolbar_title"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:maxLines="1"
-                        android:ellipsize="middle"
-                        style="@style/SchedJoules_ToolbarTitle"/>
-
-            </android.support.v7.widget.Toolbar>
+                    android:layout_height="?attr/actionBarSize"/>
 
         </android.support.design.widget.AppBarLayout>
 
         <FrameLayout
-                android:id="@+id/schedjoules_event_list_container"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
             <FrameLayout
-                    android:id="@+id/schedjoules_event_list_list_holder"
+                    android:id="@+id/schedjoules_event_list_list_container"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"/>
 

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list.xml
@@ -14,32 +14,21 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
-            <android.support.v7.widget.Toolbar
-                    android:id="@+id/schedjoules_event_list_toolbar"
+            <FrameLayout
+                    android:id="@+id/schedjoules_event_list_header_container"
                     android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize">
-
-                <TextView
-                        android:id="@+id/schedjoules_event_list_toolbar_title"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:maxLines="1"
-                        android:ellipsize="middle"
-                        style="@style/SchedJoules_ToolbarTitle"/>
-
-            </android.support.v7.widget.Toolbar>
+                    android:layout_height="?attr/actionBarSize"/>
 
         </android.support.design.widget.AppBarLayout>
 
         <FrameLayout
-                android:id="@+id/schedjoules_event_list_container"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
 
             <FrameLayout
-                    android:id="@+id/schedjoules_event_list_list_holder"
+                    android:id="@+id/schedjoules_event_list_list_container"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"/>
 

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list_header.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list_header.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <android.support.v7.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+            android:id="@+id/schedjoules_event_list_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize">
+
+        <TextView
+                android:id="@+id/schedjoules_event_list_toolbar_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:maxLines="1"
+                android:ellipsize="middle"
+                style="@style/SchedJoules_ToolbarTitle"/>
+
+    </android.support.v7.widget.Toolbar>
+</layout>

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list_list_error.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list_list_error.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+        <com.schedjoules.eventdiscovery.framework.widgets.StateSavingTextView
+                android:id="@+id/schedjoules_event_list_background_message"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_margin="@dimen/schedjoules_activity_horizontal_margin"
+                android:paddingBottom="30dp"
+                android:textSize="16sp"
+                android:gravity="center"
+                android:text="@string/schedjoules_event_list_error_bg_msg"
+                android:layout_gravity="center"/>
+
+        <include layout="@layout/schedjoules_view_schedjoules_footer"/>
+
+    </FrameLayout>
+</layout>

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list_list_loader.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list_list_loader.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
+            android:id="@+id/schedjoules_event_list_progress_bar"
+            android:layout_gravity="center"
+            android:layout_width="@dimen/schedjoules_event_list_progress_bar"
+            android:layout_height="@dimen/schedjoules_event_list_progress_bar"/>
+
+    <include layout="@layout/schedjoules_view_schedjoules_footer"/>
+
+</FrameLayout>

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list_list_show.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_fragment_event_list_list_show.xml
@@ -16,24 +16,6 @@
                 app:layoutManager="LinearLayoutManager"
                 android:layout_marginBottom="24dp"/>
 
-        <com.schedjoules.eventdiscovery.framework.widgets.StateSavingTextView
-                android:id="@+id/schedjoules_event_list_background_message"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_margin="@dimen/schedjoules_activity_horizontal_margin"
-                android:paddingBottom="30dp"
-                android:textSize="16sp"
-                android:visibility="gone"
-                android:gravity="center"
-                android:layout_gravity="center"/>
-
-        <com.schedjoules.eventdiscovery.framework.widgets.AccentColoredProgressBar
-                android:id="@+id/schedjoules_event_list_progress_bar"
-                android:layout_gravity="center"
-                android:visibility="gone"
-                android:layout_width="@dimen/schedjoules_event_list_progress_bar"
-                android:layout_height="@dimen/schedjoules_event_list_progress_bar"/>
-
         <com.schedjoules.eventdiscovery.framework.microfragments.eventdetails.fragments.views.SchedJoulesFooterView xmlns:app="http://schemas.android.com/apk/res-auto"
                 xmlns:android="http://schemas.android.com/apk/res/android"
                 android:id="@+id/schedjoules_footer"

--- a/eventdiscovery-sdk/src/main/res/layout/schedjoules_view_schedjoules_footer.xml
+++ b/eventdiscovery-sdk/src/main/res/layout/schedjoules_view_schedjoules_footer.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.schedjoules.eventdiscovery.framework.microfragments.eventdetails.fragments.views.SchedJoulesFooterView xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/schedjoules_footer"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:paddingLeft="@dimen/schedjoules_activity_horizontal_margin"
+        android:paddingRight="@dimen/schedjoules_activity_horizontal_margin"
+        android:paddingStart="@dimen/schedjoules_activity_horizontal_margin"
+        android:paddingEnd="@dimen/schedjoules_activity_horizontal_margin"
+        android:paddingTop="6dp"
+        android:paddingBottom="6dp"
+        android:background="?attr/schedjoules_cardBackgroundColor"
+        android:gravity="right|end|center"
+        android:layout_gravity="bottom|end|right"
+        android:drawableRight="?attr/schedjoules_schedJoulesAttribution"
+        android:drawableEnd="?attr/schedjoules_schedJoulesAttribution"
+        android:textSize="0sp"/>


### PR DESCRIPTION
Submitting this now, but this has to be rebased after #282 is merged.

Code in the original list fragment got significantly simpler by this separation nicely.

Notes:
I've created a `BoxDovecote` which can use a `Box<T>` as pigeon payload and `T` as callback value, used it at one point, but not needed in the end (because of `LoadResult`), still kept it thinking that it might be useful later.

Created this to represent the loading result that can be sent with the pigeon:
```
interface LoadResult<T> extends Parcelable
{
    boolean isSuccess();
    T result() throws IllegalStateException;
}
```
It's very similar to `Optional` but this felt more appropriate for me here. Having an absent value would not be the same semantically for me as having a failed load. Also this is a `Parcelable` so we can use it with `ParcelableDoveCote`.

I've also added some support for standard Fragment transactions.

And a `FragmentBuilder` for convenience, to avoid the `setArgs()` calls, although this builder is not immutable..   so let me know if you'd rather not have that one.