### PR TITLE
Fix shadow on status bar after visiting details page. #279

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/common/BaseFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/common/BaseFragment.java
@@ -19,6 +19,10 @@ package com.schedjoules.eventdiscovery.framework.common;
 
 import android.support.v4.app.Fragment;
 
+import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.utils.colors.AttributeColor;
+import com.schedjoules.eventdiscovery.framework.utils.colors.Transparent;
+
 
 /**
  * Base class for all Fragments in the app.
@@ -28,4 +32,12 @@ import android.support.v4.app.Fragment;
 public abstract class BaseFragment extends Fragment
 {
 
+    /**
+     * Sets whether the the View of this Fragment can cover the status bar.
+     */
+    protected void setStatusBarCoverEnabled(boolean enabled)
+    {
+        new StatusBar(getActivity()).update(enabled ?
+                Transparent.INSTANCE : new AttributeColor(getContext(), R.attr.colorPrimaryDark));
+    }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListFragment.java
@@ -85,6 +85,8 @@ public final class EventListFragment extends BaseFragment implements EventListMe
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
     {
+        setStatusBarCoverEnabled(false);
+
         mViews = DataBindingUtil.inflate(inflater, R.layout.schedjoules_fragment_event_list, container, false);
 
         mMenu = new EventListMenu(this);

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListShowFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListListShowFragment.java
@@ -90,6 +90,7 @@ public final class EventListListShowFragment extends BaseFragment
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
     {
         mViews = DataBindingUtil.inflate(inflater, R.layout.schedjoules_fragment_event_list_list_show, container, false);
+        setStatusBarCoverEnabled(false);
 
         initAdapterAndRecyclerView(mIsInitializing);
         if (mIsInitializing)

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/locationpicker/LocationPickerFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/locationpicker/LocationPickerFragment.java
@@ -119,6 +119,8 @@ public final class LocationPickerFragment extends BaseFragment
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
     {
+        setStatusBarCoverEnabled(false);
+
         SchedjoulesFragmentLocationPickerBinding views = DataBindingUtil.inflate(inflater,
                 R.layout.schedjoules_fragment_location_picker, container, false);
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ActionLoaderMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ActionLoaderMicroFragment.java
@@ -32,6 +32,7 @@ import android.view.ViewGroup;
 import com.schedjoules.client.eventsdiscovery.Event;
 import com.schedjoules.eventdiscovery.R;
 import com.schedjoules.eventdiscovery.databinding.SchedjoulesFragmentEventDetailsContentLoadingActionsBinding;
+import com.schedjoules.eventdiscovery.framework.common.BaseFragment;
 import com.schedjoules.eventdiscovery.framework.microfragments.eventdetails.fragments.views.EventHeaderView;
 import com.schedjoules.eventdiscovery.framework.model.ParcelableEvent;
 import com.schedjoules.eventdiscovery.framework.services.ActionService;
@@ -132,7 +133,7 @@ public final class ActionLoaderMicroFragment implements MicroFragment<Event>
     }
 
 
-    public final static class LoaderFragment extends Fragment
+    public final static class LoaderFragment extends BaseFragment
     {
         private final Timestamp mTimestamp = new UiTimestamp();
         private ServiceJobQueue<ActionService> mActionServiceJobQueue;
@@ -152,6 +153,8 @@ public final class ActionLoaderMicroFragment implements MicroFragment<Event>
         @Override
         public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
         {
+            setStatusBarCoverEnabled(true);
+
             SchedjoulesFragmentEventDetailsContentLoadingActionsBinding views = DataBindingUtil.inflate(inflater,
                     R.layout.schedjoules_fragment_event_details_content_loading_actions, container, false);
 
@@ -165,6 +168,7 @@ public final class ActionLoaderMicroFragment implements MicroFragment<Event>
         public void onResume()
         {
             super.onResume();
+
             mActionServiceJobQueue.post(new ServiceJob<ActionService>()
             {
                 @Override
@@ -207,5 +211,6 @@ public final class ActionLoaderMicroFragment implements MicroFragment<Event>
                 new FragmentEnvironment<>(this).host().execute(getActivity(), fragmentTransition);
             }
         }
+
     }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ErrorMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ErrorMicroFragment.java
@@ -29,6 +29,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.common.BaseFragment;
 
 import net.opacapp.multilinecollapsingtoolbar.CollapsingToolbarLayout;
 
@@ -150,12 +151,13 @@ public final class ErrorMicroFragment implements MicroFragment<ErrorMicroFragmen
     }
 
 
-    public final static class ErrorFragment extends Fragment
+    public final static class ErrorFragment extends BaseFragment
     {
         @Nullable
         @Override
         public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
         {
+            setStatusBarCoverEnabled(true);
             View view = inflater.inflate(R.layout.schedjoules_fragment_event_details_error, container, false);
             Error error = new FragmentEnvironment<Error>(this).microFragment().parameter();
             String title = error.title();
@@ -175,5 +177,6 @@ public final class ErrorMicroFragment implements MicroFragment<ErrorMicroFragmen
             }
             return view;
         }
+
     }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/EventLoaderMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/EventLoaderMicroFragment.java
@@ -30,6 +30,7 @@ import android.view.ViewGroup;
 import com.schedjoules.client.eventsdiscovery.Event;
 import com.schedjoules.client.eventsdiscovery.queries.EventByUid;
 import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.common.BaseFragment;
 import com.schedjoules.eventdiscovery.framework.services.ActionService;
 import com.schedjoules.eventdiscovery.framework.utils.ServiceJob;
 import com.schedjoules.eventdiscovery.framework.utils.ServiceJobQueue;
@@ -132,7 +133,7 @@ public final class EventLoaderMicroFragment implements MicroFragment<String>
     }
 
 
-    public final static class LoaderFragment extends Fragment
+    public final static class LoaderFragment extends BaseFragment
     {
         private final Timestamp mTimestamp = new UiTimestamp();
         private ServiceJobQueue<ActionService> mActionServiceJobQueue;
@@ -156,6 +157,7 @@ public final class EventLoaderMicroFragment implements MicroFragment<String>
         @Override
         public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
         {
+            setStatusBarCoverEnabled(true);
             View view = inflater.inflate(R.layout.schedjoules_fragment_event_details_loader, container, false);
             view.findViewById(android.R.id.message).animate().setStartDelay(1500).alpha(1).start();
             ((CollapsingToolbarLayout) view.findViewById(R.id.schedjoules_event_detail_toolbar_layout)).setTitle("Loading event …");
@@ -247,5 +249,6 @@ public final class EventLoaderMicroFragment implements MicroFragment<String>
                 new FragmentEnvironment<>(this).host().execute(getActivity(), fragmentTransition);
             }
         }
+
     }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/EventDetailFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/EventDetailFragment.java
@@ -58,6 +58,8 @@ public final class EventDetailFragment extends BaseFragment implements EventDeta
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
     {
+        setStatusBarCoverEnabled(true);
+
         final MicroFragmentEnvironment<ShowEventMicroFragment.EventParams> environment = new FragmentEnvironment<>(this);
         ShowEventMicroFragment.EventParams parameters = environment.microFragment().parameter();
 
@@ -126,4 +128,5 @@ public final class EventDetailFragment extends BaseFragment implements EventDeta
             }
         });
     }
+
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/views/EventHeaderView.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/fragments/views/EventHeaderView.java
@@ -26,10 +26,8 @@ import com.bumptech.glide.Glide;
 import com.schedjoules.client.eventsdiscovery.Event;
 import com.schedjoules.eventdiscovery.R;
 import com.schedjoules.eventdiscovery.databinding.SchedjoulesDetailsHeaderBinding;
-import com.schedjoules.eventdiscovery.framework.common.StatusBar;
 import com.schedjoules.eventdiscovery.framework.utils.SchedJoulesLinks;
 import com.schedjoules.eventdiscovery.framework.utils.colors.AttributeColor;
-import com.schedjoules.eventdiscovery.framework.utils.colors.Transparent;
 import com.schedjoules.eventdiscovery.framework.utils.smartview.SmartView;
 
 
@@ -56,8 +54,6 @@ public final class EventHeaderView implements SmartView<Event>
     @Override
     public void update(Event event)
     {
-        new StatusBar(mActivity).update(Transparent.INSTANCE);
-
         Glide.with(mActivity)
                 .load(new SchedJoulesLinks(event.links()).bannerUri())
                 .into(mHeader.schedjoulesEventDetailBanner);

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/feedback/FeedbackMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/feedback/FeedbackMicroFragment.java
@@ -30,6 +30,7 @@ import android.view.ViewGroup;
 
 import com.schedjoules.client.queries.FeedbackUrl;
 import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.common.BaseFragment;
 import com.schedjoules.eventdiscovery.framework.microfragments.eventdetails.ErrorMicroFragment;
 import com.schedjoules.eventdiscovery.framework.microfragments.webview.WebviewMicroFragment;
 import com.schedjoules.eventdiscovery.framework.utils.ServiceJob;
@@ -127,7 +128,7 @@ public final class FeedbackMicroFragment implements MicroFragment<Void>
     }
 
 
-    public final static class LoaderFragment extends Fragment
+    public final static class LoaderFragment extends BaseFragment
     {
         private final Timestamp mTimestamp = new UiTimestamp();
         private ServiceJobQueue<ApiService> mApiServiceJobQueue;
@@ -147,6 +148,8 @@ public final class FeedbackMicroFragment implements MicroFragment<Void>
         @Override
         public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
         {
+            setStatusBarCoverEnabled(false);
+
             mEnvironment = new FragmentEnvironment<>(this);
 
             View root = inflater.inflate(R.layout.schedjoules_fragment_loading_feedback, container, false);
@@ -231,5 +234,6 @@ public final class FeedbackMicroFragment implements MicroFragment<Void>
                 new FragmentEnvironment<>(this).host().execute(getActivity(), fragmentTransition);
             }
         }
+
     }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/webview/WebviewMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/webview/WebviewMicroFragment.java
@@ -39,6 +39,7 @@ import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
 
 import com.schedjoules.eventdiscovery.R;
+import com.schedjoules.eventdiscovery.framework.common.BaseFragment;
 
 import org.dmfs.android.microfragments.FragmentEnvironment;
 import org.dmfs.android.microfragments.MicroFragment;
@@ -131,7 +132,7 @@ public final class WebviewMicroFragment implements MicroFragment<URI>
     /**
      * A fragment that presents a website.
      */
-    public static final class WebviewFragment extends Fragment implements View.OnKeyListener
+    public static final class WebviewFragment extends BaseFragment implements View.OnKeyListener
     {
         private WebView mWebView;
         private ProgressBar mProgress;
@@ -152,6 +153,8 @@ public final class WebviewMicroFragment implements MicroFragment<URI>
         @Override
         public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
         {
+            setStatusBarCoverEnabled(false);
+
             View root = inflater.inflate(R.layout.schedjoules_fragment_webview, container, false);
             mEnvironment = new FragmentEnvironment<>(this);
             // create and configure the WebView
@@ -256,5 +259,6 @@ public final class WebviewMicroFragment implements MicroFragment<URI>
             }
             return false;
         }
+
     }
 }


### PR DESCRIPTION
I've fixed it by turning the transparent status bar on and off in `onResume()` and `onPause()` of the event details fragments. Not sure if this is the best way but we don't need to touch the other fragments with this.

During the transitions the shadow is still there. Not sure if that can be eliminated easily though.
So an option can be, I suppose, is to use this fix and fine tune it later if needed.