### PR TITLE
Add utility to force parcelling to be able to test it. #292

### DIFF
--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/commons/BundleBuilder.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/commons/BundleBuilder.java
@@ -67,6 +67,8 @@ public final class BundleBuilder implements FluentBuilder<Bundle>
     {
         Bundle bundle = new Bundle(mBundle);
         bundle.putParcelable(key.name(), box);
+        // Use this to test parcelling during development:
+        // bundle.putParcelable(key.name(), ParcellingEnforcer.immediateDeepParcel(box));
         return new BundleBuilder(bundle, false);
     }
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/ParcellingEnforcer.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/ParcellingEnforcer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+
+/**
+ * Util method to cause immediate deep parcelling of a {@link Parcelable}.
+ * Can be used to test if {@link Parcelable} implementations work correctly.
+ * <p>
+ * From https://gist.github.com/patrickhammond/732d20b6e89fda23be1b
+ */
+public class ParcellingEnforcer
+{
+    public static Parcelable immediateDeepParcel(Parcelable input)
+    {
+        return immediateDeepParcel(input, input.getClass().getClassLoader());
+    }
+
+
+    public static Parcelable immediateDeepParcel(Parcelable input, ClassLoader classLoader)
+    {
+        Parcel parcel = null;
+        try
+        {
+            parcel = Parcel.obtain();
+            parcel.writeParcelable(input, 0);
+            parcel.setDataPosition(0);
+            return parcel.readParcelable(classLoader);
+        }
+        finally
+        {
+            if (parcel != null)
+            {
+                parcel.recycle();
+            }
+        }
+    }
+}


### PR DESCRIPTION
I've already used this on branch 276 to test the parcelling, so I thought we can add this to the code base, so we have it at hand. This is only a util method that can be called in `BundleBuilder` which will ensure deep parcelling of the parameters.

Note: I've also tried testing with "Don't keep Activities" and use the kill process button in Android Studio, but none of them looked appropriate for this.
