### PR TITLE
Add network call times logging to request logging. #294

### DIFF
--- a/eventdiscovery-demo/src/main/java/com/schedjoules/eventdiscovery/demo/ApiService.java
+++ b/eventdiscovery-demo/src/main/java/com/schedjoules/eventdiscovery/demo/ApiService.java
@@ -8,7 +8,7 @@ import com.schedjoules.client.Api;
 import com.schedjoules.client.SchedJoulesApi;
 import com.schedjoules.client.SchedJoulesApiClient;
 import com.schedjoules.client.utils.StringAccessToken;
-import com.schedjoules.eventdiscovery.framework.http.RequestUriLogging;
+import com.schedjoules.eventdiscovery.framework.http.RequestUriAndTimeLogging;
 import com.schedjoules.eventdiscovery.framework.utils.SharedPrefsUserIdentifier;
 import com.schedjoules.eventdiscovery.service.AbstractApiService;
 
@@ -40,7 +40,7 @@ public final class ApiService extends AbstractApiService
                 SchedJoulesApiClient client = new SchedJoulesApiClient(new StringAccessToken("0443a55244bb2b6224fd48e0416f0d9c"));
 
                 HttpRequestExecutor executor =
-                        new RequestUriLogging(
+                        new RequestUriAndTimeLogging(
                                 new Branded(
                                         new Retrying(
                                                 new HttpUrlConnectionExecutor(


### PR DESCRIPTION
Simple addition to the existing request logging to log the times as well.

I've added this locally first just to check the categories call times, but I thought it can be good to have it in permanently for the demo app, so we can nicely see the call times always.