### PR TITLE
Use bottom-up transition for showing details screen. #281

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/eventdiscovery-demo/src/main/java/com/schedjoules/eventdiscovery/demo/MainActivity.java
+++ b/eventdiscovery-demo/src/main/java/com/schedjoules/eventdiscovery/demo/MainActivity.java
@@ -76,6 +76,6 @@ public final class MainActivity extends AppCompatActivity
 
     public void onEventDetailsByUid(View view)
     {
-        new UidEventDetails("ada36d012294c9c4").show(this);
+        new UidEventDetails("9a5813529e9b055f").show(this);
     }
 }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/eventdetails/BasicEventDetails.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/eventdetails/BasicEventDetails.java
@@ -26,12 +26,12 @@ import com.schedjoules.eventdiscovery.framework.microfragments.eventdetails.Acti
 import com.schedjoules.eventdiscovery.framework.microfragments.eventdetails.ShowEventMicroFragment;
 import com.schedjoules.eventdiscovery.framework.services.ActionService;
 import com.schedjoules.eventdiscovery.framework.utils.FutureServiceConnection;
+import com.schedjoules.eventdiscovery.framework.utils.anims.BottomUp;
 
 import org.dmfs.android.microfragments.MicroFragment;
 import org.dmfs.android.microfragments.Timestamp;
 import org.dmfs.android.microfragments.timestamps.UiTimestamp;
 import org.dmfs.android.microfragments.transitions.ForwardTransition;
-import org.dmfs.android.microfragments.transitions.Swiped;
 import org.dmfs.httpessentials.types.Link;
 import org.dmfs.optional.Absent;
 import org.dmfs.optional.Optional;
@@ -73,7 +73,7 @@ public final class BasicEventDetails implements EventDetails
                         new ShowEventMicroFragment(mEvent, actions.value()) : new ActionLoaderMicroFragment(mEvent);
 
                 new ActivityMicroFragmentHost(activity).get()
-                        .execute(activity, new Swiped(new ForwardTransition<>(microFragment, timestamp)));
+                        .execute(activity, new BottomUp(new ForwardTransition<>(microFragment, timestamp)));
             }
 
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ActionLoaderMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/ActionLoaderMicroFragment.java
@@ -38,13 +38,13 @@ import com.schedjoules.eventdiscovery.framework.services.ActionService;
 import com.schedjoules.eventdiscovery.framework.utils.ServiceJob;
 import com.schedjoules.eventdiscovery.framework.utils.ServiceJobQueue;
 import com.schedjoules.eventdiscovery.framework.utils.SimpleServiceJobQueue;
+import com.schedjoules.eventdiscovery.framework.utils.anims.Revealed;
 
 import org.dmfs.android.microfragments.FragmentEnvironment;
 import org.dmfs.android.microfragments.MicroFragment;
 import org.dmfs.android.microfragments.MicroFragmentHost;
 import org.dmfs.android.microfragments.Timestamp;
 import org.dmfs.android.microfragments.timestamps.UiTimestamp;
-import org.dmfs.android.microfragments.transitions.Faded;
 import org.dmfs.android.microfragments.transitions.ForwardTransition;
 import org.dmfs.android.microfragments.transitions.FragmentTransition;
 import org.dmfs.httpessentials.exceptions.ProtocolError;
@@ -173,12 +173,12 @@ public final class ActionLoaderMicroFragment implements MicroFragment<Event>
                     try
                     {
                         List<Link> links = service.actions(mEvent.uid());
-                        startTransition(new Faded(new ForwardTransition(new ShowEventMicroFragment(mEvent, links), mTimestamp)));
+                        startTransition(new Revealed(new ForwardTransition(new ShowEventMicroFragment(mEvent, links), mTimestamp)));
                     }
                     catch (TimeoutException | InterruptedException | ProtocolError | IOException | ProtocolException | URISyntaxException | RuntimeException e)
                     {
                         // for some reason we were unable to load the actions, move on without actions.
-                        startTransition(new Faded(new ForwardTransition(new ShowEventMicroFragment(mEvent, Collections.<Link>emptyList()), mTimestamp)));
+                        startTransition(new Revealed(new ForwardTransition(new ShowEventMicroFragment(mEvent, Collections.<Link>emptyList()), mTimestamp)));
                     }
                 }
 
@@ -186,7 +186,7 @@ public final class ActionLoaderMicroFragment implements MicroFragment<Event>
                 @Override
                 public void onTimeOut()
                 {
-                    startTransition(new Faded(new ForwardTransition(new ErrorMicroFragment(), mTimestamp)));
+                    startTransition(new Revealed(new ForwardTransition(new ErrorMicroFragment(), mTimestamp)));
                 }
             }, 5000);
         }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/EventLoaderMicroFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/microfragments/eventdetails/EventLoaderMicroFragment.java
@@ -34,6 +34,7 @@ import com.schedjoules.eventdiscovery.framework.services.ActionService;
 import com.schedjoules.eventdiscovery.framework.utils.ServiceJob;
 import com.schedjoules.eventdiscovery.framework.utils.ServiceJobQueue;
 import com.schedjoules.eventdiscovery.framework.utils.SimpleServiceJobQueue;
+import com.schedjoules.eventdiscovery.framework.utils.anims.Revealed;
 import com.schedjoules.eventdiscovery.service.ApiService;
 
 import net.opacapp.multilinecollapsingtoolbar.CollapsingToolbarLayout;
@@ -43,7 +44,6 @@ import org.dmfs.android.microfragments.MicroFragment;
 import org.dmfs.android.microfragments.MicroFragmentHost;
 import org.dmfs.android.microfragments.Timestamp;
 import org.dmfs.android.microfragments.timestamps.UiTimestamp;
-import org.dmfs.android.microfragments.transitions.Faded;
 import org.dmfs.android.microfragments.transitions.ForwardTransition;
 import org.dmfs.android.microfragments.transitions.FragmentTransition;
 import org.dmfs.httpessentials.exceptions.ProtocolError;
@@ -181,7 +181,7 @@ public final class EventLoaderMicroFragment implements MicroFragment<String>
                             }
                             catch (URISyntaxException | ProtocolError | ProtocolException | IOException | RuntimeException e)
                             {
-                                startTransition(new Faded(new ForwardTransition(new ErrorMicroFragment(), mTimestamp)));
+                                startTransition(new Revealed(new ForwardTransition(new ErrorMicroFragment(), mTimestamp)));
                             }
                         }
 
@@ -189,7 +189,7 @@ public final class EventLoaderMicroFragment implements MicroFragment<String>
                         @Override
                         public void onTimeOut()
                         {
-                            startTransition(new Faded(new ForwardTransition(new ErrorMicroFragment(), mTimestamp)));
+                            startTransition(new Revealed(new ForwardTransition(new ErrorMicroFragment(), mTimestamp)));
                         }
                     }, 5000);
             mActionServiceJobQueue.post(
@@ -215,7 +215,7 @@ public final class EventLoaderMicroFragment implements MicroFragment<String>
                         @Override
                         public void onTimeOut()
                         {
-                            startTransition(new Faded(new ForwardTransition(new ErrorMicroFragment(), mTimestamp)));
+                            startTransition(new Revealed(new ForwardTransition(new ErrorMicroFragment(), mTimestamp)));
                         }
                     }, 5000
             );
@@ -235,7 +235,7 @@ public final class EventLoaderMicroFragment implements MicroFragment<String>
         {
             if (mEvent != null && mActions != null)
             {
-                startTransition(new Faded(new ForwardTransition(new ShowEventMicroFragment(mEvent, mActions), mTimestamp)));
+                startTransition(new Revealed(new ForwardTransition(new ShowEventMicroFragment(mEvent, mActions), mTimestamp)));
             }
         }
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/anims/AbstractAnimated.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/anims/AbstractAnimated.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.anims;
+
+import android.content.Context;
+import android.os.Parcel;
+import android.support.annotation.AnimRes;
+import android.support.annotation.NonNull;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
+
+import org.dmfs.android.microfragments.MicroFragment;
+import org.dmfs.android.microfragments.MicroFragmentHost;
+import org.dmfs.android.microfragments.Timestamp;
+import org.dmfs.android.microfragments.transitions.FragmentTransition;
+
+
+/**
+ * Abstract class for {@link FragmentTransition}s decorators that add animations.
+ *
+ * @author Gabor Keszthelyi
+ */
+public abstract class AbstractAnimated implements FragmentTransition
+{
+    private final FragmentTransition mDelegate;
+    private final int mEnter;
+    private final int mExit;
+    private final int mPopEnter;
+    private final int mPopExit;
+
+
+    protected AbstractAnimated(@NonNull FragmentTransition delegate,
+                               @AnimRes int enter, @AnimRes int exit, @AnimRes int popEnter, @AnimRes int popExit)
+    {
+        mDelegate = delegate;
+        mEnter = enter;
+        mExit = exit;
+        mPopEnter = popEnter;
+        mPopExit = popExit;
+    }
+
+
+    protected AbstractAnimated(Parcel in)
+    {
+        this((FragmentTransition) in.readParcelable(AbstractAnimated.class.getClassLoader()),
+                in.readInt(), in.readInt(), in.readInt(), in.readInt());
+    }
+
+
+    @NonNull
+    @Override
+    public final Timestamp timestamp()
+    {
+        return mDelegate.timestamp();
+    }
+
+
+    @Override
+    public final void prepare(@NonNull Context context, @NonNull FragmentManager fragmentManager, @NonNull MicroFragmentHost host, @NonNull MicroFragment<?> previousStep)
+    {
+        mDelegate.prepare(context, fragmentManager, host, previousStep);
+    }
+
+
+    @NonNull
+    @Override
+    public final FragmentTransaction updateTransaction(@NonNull Context context, @NonNull FragmentTransaction fragmentTransaction, @NonNull FragmentManager fragmentManager, @NonNull MicroFragmentHost host, @NonNull MicroFragment<?> previousStep)
+    {
+        fragmentTransaction.setCustomAnimations(mEnter, mExit, mPopEnter, mPopExit);
+        return mDelegate.updateTransaction(context, fragmentTransaction, fragmentManager, host, previousStep);
+    }
+
+
+    @Override
+    public final void cleanup(@NonNull Context context, @NonNull FragmentManager fragmentManager, @NonNull MicroFragmentHost host, @NonNull MicroFragment<?> previousStep)
+    {
+        mDelegate.cleanup(context, fragmentManager, host, previousStep);
+    }
+
+
+    @Override
+    public final int describeContents()
+    {
+        return 0;
+    }
+
+
+    @Override
+    public final void writeToParcel(Parcel dest, int flags)
+    {
+        dest.writeParcelable(mDelegate, flags);
+        dest.writeInt(mEnter);
+        dest.writeInt(mExit);
+        dest.writeInt(mPopEnter);
+        dest.writeInt(mPopExit);
+    }
+
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/anims/BottomUp.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/anims/BottomUp.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.anims;
+
+import android.os.Parcel;
+import android.support.annotation.NonNull;
+
+import com.schedjoules.eventdiscovery.R;
+
+import org.dmfs.android.microfragments.transitions.FragmentTransition;
+
+
+/**
+ * {@link FragmentTransition} decorator to add animation:
+ * Slide in the new fragment from the bottom on top of the existing one.
+ * Exiting is fade-out fade-in.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class BottomUp extends AbstractAnimated
+{
+    public BottomUp(@NonNull FragmentTransition delegate)
+    {
+        super(delegate,
+                R.anim.microfragments_swipe_bottom_up_enter,
+                R.anim.microfragments_none,
+                R.anim.microfragments_fade_enter,
+                R.anim.microfragments_fade_exit);
+    }
+
+
+    private BottomUp(Parcel in)
+    {
+        super(in);
+    }
+
+
+    public final static Creator<BottomUp> CREATOR = new Creator<BottomUp>()
+    {
+        @Override
+        public BottomUp createFromParcel(Parcel in)
+        {
+            return new BottomUp(in);
+        }
+
+
+        @Override
+        public BottomUp[] newArray(int size)
+        {
+            return new BottomUp[size];
+        }
+    };
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/anims/Revealed.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/anims/Revealed.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils.anims;
+
+import android.os.Parcel;
+import android.support.annotation.NonNull;
+
+import com.schedjoules.eventdiscovery.R;
+
+import org.dmfs.android.microfragments.transitions.FragmentTransition;
+
+
+/**
+ * {@link FragmentTransition} decorator to add animation:
+ * Fades the old fragment out to reveal the new one.
+ * Exiting is fade-out fade-in.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class Revealed extends AbstractAnimated
+{
+    public Revealed(@NonNull FragmentTransition delegate)
+    {
+        super(delegate,
+                R.anim.microfragments_none,
+                R.anim.microfragments_fade_exit,
+                R.anim.microfragments_fade_enter,
+                R.anim.microfragments_fade_exit);
+    }
+
+
+    private Revealed(Parcel in)
+    {
+        super(in);
+    }
+
+
+    public final static Creator<Revealed> CREATOR = new Creator<Revealed>()
+    {
+        @Override
+        public Revealed createFromParcel(Parcel in)
+        {
+            return new Revealed(in);
+        }
+
+
+        @Override
+        public Revealed[] newArray(int size)
+        {
+            return new Revealed[size];
+        }
+    };
+}


### PR DESCRIPTION
Note: submitted this now for merging to 278, but we should go ahead with that instead and rebase this one on categories/master after that.

I used bottom-up for entering and fade-out for exiting. I tried with the bottom-up exit animation as well but that didn't look good. Tried to tweak it a bit as well, but couldn't make it nice quickly so I thought this fade-out looks good enough for now. I think if these animations represent an _okay_ version now then we should go ahead and just put an improvement ticket in the backlog if needed, which we can get back to after categories are implemented.