### PR TITLE
Fix initialization check in EventListFragment to avoid duplicate Head…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListFragment.java
@@ -136,7 +136,8 @@ public final class EventListFragment extends BaseFragment implements EventListMe
             }
         });
 
-        if (mIsInitializing)
+        // savedInstanceState can be null when popping an existing instance from backstack
+        if (savedInstanceState == null && mIsInitializing)
         {
             new Add(R.id.schedjoules_event_list_header_container, EventListHeaderFragment.newInstance(mReloadDovecote.cage())).commit(this);
 


### PR DESCRIPTION
…erFragment. #315 

Note: this branch is based on #278 

@dmfs This is a one line change, after you've checked, I would like to propose again to move this to a base Fragment. We need to check 2 things in order to correctly determine if a Fragment is initializing, because `savedInstanceState` can be `null` when popping existing instance from backstack.
So in order to avoid having to think it through every time, and also avoid code duplication, we could move it to a base Fragment.
I see it as a framework functionality, so something which the framework could also provide us (maybe it even _should_ in this case). And such things for me are fine going into base classes.

So the proposal:
```java
class BaseFragment
{
    private boolean mIsNewInstance = true;

    public final View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
            @Nullable Bundle savedInstanceState) {
        View view = onCreateView(inflater, container, savedInstanceState, savedInstanceState == null && mIsNewInstance)
        mIsNewInstance = false;
        return view;
    }

    public abstract View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
            @Nullable Bundle savedInstanceState, boolean isInitializing);
}

```