### PR TITLE
Save and restore Categories cache when Activity is recreated after sy…

### DIFF
--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/activities/MicroFragmentHostActivity.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/activities/MicroFragmentHostActivity.java
@@ -21,9 +21,12 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 
 import com.schedjoules.eventdiscovery.framework.common.BaseActivity;
+import com.schedjoules.eventdiscovery.framework.common.CategoriesCache;
 import com.schedjoules.eventdiscovery.framework.serialization.Keys;
+import com.schedjoules.eventdiscovery.framework.serialization.boxes.CategoriesBox;
 import com.schedjoules.eventdiscovery.framework.serialization.boxes.ParcelableBox;
 import com.schedjoules.eventdiscovery.framework.serialization.commons.Argument;
+import com.schedjoules.eventdiscovery.framework.serialization.commons.FluentBundle;
 import com.schedjoules.eventdiscovery.framework.serialization.commons.IntentBuilder;
 
 import org.dmfs.android.microfragments.MicroFragment;
@@ -49,6 +52,13 @@ public final class MicroFragmentHostActivity extends BaseActivity
     protected void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
+
+        if (savedInstanceState != null)
+        {
+            // Categories cache restoration is needed for the case when Activity is restored after being killed
+            // (It wouldn't be needed for config change - that's handled by ViewModel)
+            new CategoriesCache(new Argument<>(Keys.CATEGORIES, savedInstanceState).get()).cache(this);
+        }
 
         // the BackDovecote receives Pigeons with the result of the BackTransition.
         mBackDovecote = new BooleanDovecote(this, "backresult", new Dovecote.OnPigeonReturnCallback<Boolean>()
@@ -87,9 +97,9 @@ public final class MicroFragmentHostActivity extends BaseActivity
     {
         super.onSaveInstanceState(outState);
 
-        // TODO Possibly create mutable State abstraction that holds all state for the Activity.
-        // TODO Key should not be used like this:
-        outState.putParcelable(Keys.MICRO_FRAGMENT_HOST.name(), new ParcelableBox<>(mMicroFragmentHost));
+        new FluentBundle(outState)
+                .put(Keys.MICRO_FRAGMENT_HOST, new ParcelableBox<>(mMicroFragmentHost))
+                .put(Keys.CATEGORIES, new CategoriesBox(new CategoriesCache(this)));
     }
 
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/model/category/StructuredCategory.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/model/category/StructuredCategory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.model.category;
+
+import com.schedjoules.client.eventsdiscovery.Category;
+
+import org.dmfs.rfc3986.Uri;
+
+
+/**
+ * {@link Category} which simple takes the ready properties in the constructor.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class StructuredCategory implements Category
+{
+    private final Uri mUri;
+    private final CharSequence mLabel;
+
+
+    public StructuredCategory(Uri uri, CharSequence label)
+    {
+        mUri = uri;
+        mLabel = label;
+    }
+
+
+    @Override
+    public Uri name()
+    {
+        return mUri;
+    }
+
+
+    @Override
+    public CharSequence label()
+    {
+        return mLabel;
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/Keys.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/Keys.java
@@ -21,6 +21,7 @@ import com.schedjoules.client.eventsdiscovery.Envelope;
 import com.schedjoules.client.eventsdiscovery.Event;
 import com.schedjoules.client.eventsdiscovery.GeoLocation;
 import com.schedjoules.client.eventsdiscovery.ResultPage;
+import com.schedjoules.eventdiscovery.framework.model.category.Categories;
 import com.schedjoules.eventdiscovery.framework.serialization.core.Key;
 import com.schedjoules.eventdiscovery.framework.utils.loadresult.LoadResult;
 
@@ -54,6 +55,8 @@ public final class Keys
     public static final Key<Cage<LoadResult<ResultPage<Envelope<Event>>>>> EVENTS_LOAD_RESULT_CAGE = new SchedJoulesKey<>("EVENTS_LOAD_RESULT_CAGE");
 
     public static final Key<Cage<Boolean>> RELOAD_EVENT_LIST_CAGE = new SchedJoulesKey<>("RELOAD_EVENT_LIST_CAGE");
+
+    public static final Key<Categories> CATEGORIES = new SchedJoulesKey<>("CATEGORIES");
 
 
     private Keys()

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/CategoriesBox.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/CategoriesBox.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.serialization.boxes;
+
+import android.os.Parcel;
+
+import com.schedjoules.client.eventsdiscovery.Category;
+import com.schedjoules.eventdiscovery.framework.model.category.BasicCategories;
+import com.schedjoules.eventdiscovery.framework.model.category.Categories;
+import com.schedjoules.eventdiscovery.framework.serialization.core.Box;
+
+
+/**
+ * {@link Box} for {@link Categories}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class CategoriesBox implements Box<Categories>
+{
+    private final Categories mCategories;
+
+
+    public CategoriesBox(Categories categories)
+    {
+        mCategories = categories;
+    }
+
+
+    @Override
+    public Categories content()
+    {
+        return mCategories;
+    }
+
+
+    @Override
+    public int describeContents()
+    {
+        return 0;
+    }
+
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags)
+    {
+        dest.writeParcelable(new IterableBox<>(mCategories, CategoryBox.FACTORY), flags);
+    }
+
+
+    public static final Creator<CategoriesBox> CREATOR = new Creator<CategoriesBox>()
+    {
+        @Override
+        public CategoriesBox createFromParcel(Parcel in)
+        {
+            IterableBox<Category> categoryIterableBox = in.readParcelable(getClass().getClassLoader());
+            return new CategoriesBox(new BasicCategories(categoryIterableBox.content()));
+        }
+
+
+        @Override
+        public CategoriesBox[] newArray(int size)
+        {
+            return new CategoriesBox[size];
+        }
+    };
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/CategoryBox.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/CategoryBox.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.serialization.boxes;
+
+import android.os.Parcel;
+
+import com.schedjoules.client.eventsdiscovery.Category;
+import com.schedjoules.eventdiscovery.framework.model.category.StructuredCategory;
+import com.schedjoules.eventdiscovery.framework.serialization.commons.BoxFactory;
+import com.schedjoules.eventdiscovery.framework.serialization.core.Box;
+
+import org.dmfs.rfc3986.Uri;
+
+
+/**
+ * {@link Box} for {@link Category}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class CategoryBox implements Box<Category>
+{
+
+    private final Category mCategory;
+
+
+    public CategoryBox(Category category)
+    {
+        mCategory = category;
+    }
+
+
+    @Override
+    public Category content()
+    {
+        return mCategory;
+    }
+
+
+    @Override
+    public int describeContents()
+    {
+        return 0;
+    }
+
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags)
+    {
+        dest.writeParcelable(new UriBox(mCategory.name()), flags);
+        dest.writeString(mCategory.label().toString());
+    }
+
+
+    public static final Creator<CategoryBox> CREATOR = new Creator<CategoryBox>()
+    {
+        @Override
+        public CategoryBox createFromParcel(Parcel in)
+        {
+            Box<Uri> uriBox = in.readParcelable(getClass().getClassLoader());
+            CharSequence label = in.readString();
+            return new CategoryBox(new StructuredCategory(uriBox.content(), label));
+        }
+
+
+        @Override
+        public CategoryBox[] newArray(int size)
+        {
+            return new CategoryBox[size];
+        }
+    };
+
+    public static final BoxFactory<Category> FACTORY = new BoxFactory<Category>()
+    {
+        @Override
+        public Box<Category> create(Category category)
+        {
+            return new CategoryBox(category);
+        }
+    };
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/UriBox.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/boxes/UriBox.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.serialization.boxes;
+
+import android.os.Parcel;
+
+import com.schedjoules.eventdiscovery.framework.serialization.core.Box;
+
+import org.dmfs.rfc3986.Uri;
+import org.dmfs.rfc3986.encoding.Precoded;
+import org.dmfs.rfc3986.uris.LazyUri;
+import org.dmfs.rfc3986.uris.Text;
+
+
+/**
+ * {@link Box} for {@link Uri}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class UriBox implements Box<Uri>
+{
+    private final Uri mUri;
+
+
+    public UriBox(Uri uri)
+    {
+        mUri = uri;
+    }
+
+
+    @Override
+    public Uri content()
+    {
+        return mUri;
+    }
+
+
+    @Override
+    public int describeContents()
+    {
+        return 0;
+    }
+
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags)
+    {
+        dest.writeString(new Text(mUri).toString());
+    }
+
+
+    public static final Creator<UriBox> CREATOR = new Creator<UriBox>()
+    {
+        @Override
+        public UriBox createFromParcel(Parcel in)
+        {
+            return new UriBox(new LazyUri(new Precoded(in.readString())));
+        }
+
+
+        @Override
+        public UriBox[] newArray(int size)
+        {
+            return new UriBox[size];
+        }
+    };
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/commons/FluentBundle.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/commons/FluentBundle.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.serialization.commons;
+
+import android.os.Bundle;
+
+import com.schedjoules.eventdiscovery.framework.serialization.core.Box;
+import com.schedjoules.eventdiscovery.framework.serialization.core.Key;
+
+
+/**
+ * {@link FluentMutable} for updating a {@link Bundle}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class FluentBundle implements FluentMutable
+{
+    private final Bundle mBundle;
+
+
+    public FluentBundle(Bundle bundle)
+    {
+        mBundle = bundle;
+    }
+
+
+    @Override
+    public <T> FluentMutable put(Key<T> key, Box<T> box)
+    {
+        mBundle.putParcelable(key.name(), box);
+        return this;
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/commons/FluentMutable.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/serialization/commons/FluentMutable.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.serialization.commons;
+
+import com.schedjoules.eventdiscovery.framework.serialization.core.Box;
+import com.schedjoules.eventdiscovery.framework.serialization.core.Key;
+
+
+/**
+ * Interface for objects holding a mutable container to which parameters can be add using {@link Key} and {@link Box}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public interface FluentMutable
+{
+    /**
+     * Adds the given parameter to the underlying parametrized object.
+     *
+     * @param key
+     *         the key for this parameter
+     * @param box
+     *         the box 'containing' the value
+     * @param <T>
+     *         type of the value
+     *
+     * @return this object to allow chaining
+     */
+    <T> FluentMutable put(Key<T> key, Box<T> box);
+
+}


### PR DESCRIPTION
…stem killed it. #339 

---

I've added saving and restoring `CategoriesCache` from `savedInstanceState` in `MicroFragmentHostActivity`. This is to handle the case when Activity would be restored after it had been killed, it wouldn't be needed for just configuration changes. I've just used the `savedInstanceState != null` check nevertheless, to not complicate the logic with extra flags. Since serialization doesn't really happen on config change, I think it's fine.

I haven't been able to test this real scenario though, https://github.com/schedjoules/android-event-discovery-sdk/issues/330 will be kept open for that. So this PR is for applying a 'blind' fix for that possible crash, so that we can move forward.

I did test the parcelling added in this PR by forcing it.