### PR TITLE
Simplify ApiServices by providing defaults which satifsy the needs of…

### DIFF
--- a/eventdiscovery-demo/src/main/java/com/schedjoules/eventdiscovery/demo/ApiService.java
+++ b/eventdiscovery-demo/src/main/java/com/schedjoules/eventdiscovery/demo/ApiService.java
@@ -6,20 +6,10 @@ import android.support.annotation.NonNull;
 
 import com.schedjoules.client.Api;
 import com.schedjoules.client.SchedJoulesApi;
-import com.schedjoules.client.SchedJoulesApiClient;
 import com.schedjoules.client.utils.StringAccessToken;
 import com.schedjoules.eventdiscovery.framework.http.RequestUriAndTimeLogging;
-import com.schedjoules.eventdiscovery.framework.utils.SharedPrefsUserIdentifier;
+import com.schedjoules.eventdiscovery.framework.http.DefaultExecutor;
 import com.schedjoules.eventdiscovery.service.AbstractApiService;
-
-import org.dmfs.httpessentials.client.HttpRequestExecutor;
-import org.dmfs.httpessentials.executors.retrying.Retrying;
-import org.dmfs.httpessentials.executors.retrying.policies.DefaultRetryPolicy;
-import org.dmfs.httpessentials.executors.useragent.Branded;
-import org.dmfs.httpessentials.httpurlconnection.HttpUrlConnectionExecutor;
-import org.dmfs.httpessentials.httpurlconnection.factories.DefaultHttpUrlConnectionFactory;
-import org.dmfs.httpessentials.httpurlconnection.factories.decorators.Finite;
-import org.dmfs.httpessentials.types.VersionedProduct;
 
 
 /**
@@ -37,22 +27,12 @@ public final class ApiService extends AbstractApiService
             @Override
             public Api schedJoulesApi(@NonNull Context context)
             {
-                SchedJoulesApiClient client = new SchedJoulesApiClient(new StringAccessToken("0443a55244bb2b6224fd48e0416f0d9c"));
-
-                HttpRequestExecutor executor =
+                return new DefaultApi(
+                        context,
+                        new StringAccessToken("0443a55244bb2b6224fd48e0416f0d9c"),
                         new RequestUriAndTimeLogging(
-                                new Branded(
-                                        new Retrying(
-                                                new HttpUrlConnectionExecutor(
-                                                        new Finite(
-                                                                new DefaultHttpUrlConnectionFactory(),
-                                                                5000, 5000)),
-                                                new DefaultRetryPolicy(3)),
-                                        // make sure to use the BuildConfig of your application
-                                        new VersionedProduct(BuildConfig.APPLICATION_ID, BuildConfig.VERSION_NAME)),
-                                BuildConfig.LOG_REQUESTS, "EventDiscovery-Request");
-
-                return new SchedJoulesApi(client, executor, new SharedPrefsUserIdentifier(context));
+                                new DefaultExecutor(context),
+                                BuildConfig.LOG_REQUESTS, "EventDiscovery-Request"));
             }
         });
     }

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/http/DefaultExecutor.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/http/DefaultExecutor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.http;
+
+import android.content.Context;
+
+import com.schedjoules.eventdiscovery.framework.utils.AppProduct;
+
+import org.dmfs.httpessentials.client.HttpRequest;
+import org.dmfs.httpessentials.client.HttpRequestExecutor;
+import org.dmfs.httpessentials.exceptions.ProtocolError;
+import org.dmfs.httpessentials.exceptions.ProtocolException;
+import org.dmfs.httpessentials.exceptions.RedirectionException;
+import org.dmfs.httpessentials.exceptions.UnexpectedStatusException;
+import org.dmfs.httpessentials.executors.retrying.Retrying;
+import org.dmfs.httpessentials.executors.retrying.policies.DefaultRetryPolicy;
+import org.dmfs.httpessentials.executors.useragent.Branded;
+import org.dmfs.httpessentials.httpurlconnection.HttpUrlConnectionExecutor;
+import org.dmfs.httpessentials.httpurlconnection.factories.DefaultHttpUrlConnectionFactory;
+import org.dmfs.httpessentials.httpurlconnection.factories.decorators.Finite;
+
+import java.io.IOException;
+import java.net.URI;
+
+
+/**
+ * The default {@link HttpRequestExecutor} used by the SDK if no other has been specified.
+ *
+ * @author Marten Gajda
+ */
+public final class DefaultExecutor implements HttpRequestExecutor
+{
+    private final HttpRequestExecutor mDelegate;
+
+
+    public DefaultExecutor(Context context)
+    {
+        mDelegate = new Branded(
+                new Retrying(
+                        new HttpUrlConnectionExecutor(
+                                new Finite(
+                                        new DefaultHttpUrlConnectionFactory(),
+                                        5000, 5000)),
+                        new DefaultRetryPolicy(3)),
+                new AppProduct(context));
+    }
+
+
+    @Override
+    public <T> T execute(URI uri, HttpRequest<T> request) throws IOException, ProtocolError, ProtocolException, RedirectionException, UnexpectedStatusException
+    {
+        return mDelegate.execute(uri, request);
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/AppProduct.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/AppProduct.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 SchedJoules
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.schedjoules.eventdiscovery.framework.utils;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+
+import com.schedjoules.eventdiscovery.framework.utils.factory.Factory;
+import com.schedjoules.eventdiscovery.framework.utils.factory.Lazy;
+import com.schedjoules.eventdiscovery.framework.utils.factory.SimpleLazy;
+
+import org.dmfs.httpessentials.types.Product;
+import org.dmfs.httpessentials.types.VersionedProduct;
+
+
+/**
+ * The {@link Product} of the current app.
+ *
+ * @author Marten Gajda
+ */
+public final class AppProduct implements Product
+{
+    private final Lazy<Product> mProduct;
+
+
+    public AppProduct(final Context context)
+    {
+        mProduct = new SimpleLazy<>(new Factory<Product>()
+        {
+            @Override
+            public Product create()
+            {
+                String packageName = context.getPackageName();
+                try
+                {
+                    return new VersionedProduct(packageName, context.getPackageManager().getPackageInfo(packageName, 0).versionName);
+                }
+                catch (PackageManager.NameNotFoundException e)
+                {
+                    throw new RuntimeException("Own Packagename not found?! o_O");
+                }
+            }
+        });
+    }
+
+
+    @Override
+    public void appendTo(StringBuilder sb)
+    {
+        mProduct.get().appendTo(sb);
+    }
+}

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/service/AbstractApiService.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/service/AbstractApiService.java
@@ -25,13 +25,21 @@ import android.os.IBinder;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.schedjoules.client.AccessToken;
 import com.schedjoules.client.Api;
 import com.schedjoules.client.ApiQuery;
+import com.schedjoules.client.SchedJoulesApi;
+import com.schedjoules.client.SchedJoulesApiClient;
+import com.schedjoules.eventdiscovery.framework.http.DefaultExecutor;
+import com.schedjoules.eventdiscovery.framework.utils.SharedPrefsUserIdentifier;
 
+import org.dmfs.httpessentials.client.HttpRequest;
+import org.dmfs.httpessentials.client.HttpRequestExecutor;
 import org.dmfs.httpessentials.exceptions.ProtocolError;
 import org.dmfs.httpessentials.exceptions.ProtocolException;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 
 
@@ -95,6 +103,39 @@ public abstract class AbstractApiService extends Service
         public <T> T apiResponse(@NonNull ApiQuery<T> query) throws URISyntaxException, ProtocolError, ProtocolException, IOException
         {
             return query.queryResult(mApi);
+        }
+    }
+
+
+    /**
+     * The default SchedJoules {@link Api} to be used by most partners.
+     *
+     * @author Marten Gajda
+     */
+    public static final class DefaultApi implements Api
+    {
+        private final Api mDelegate;
+
+
+        public DefaultApi(Context context, AccessToken accessToken)
+        {
+            this(context, accessToken, new DefaultExecutor(context));
+        }
+
+
+        public DefaultApi(Context context, AccessToken accessToken, HttpRequestExecutor executor)
+        {
+            mDelegate = new SchedJoulesApi(
+                    new SchedJoulesApiClient(accessToken),
+                    executor,
+                    new SharedPrefsUserIdentifier(context));
+        }
+
+
+        @Override
+        public <T> T queryResult(URI uri, HttpRequest<T> httpRequest) throws ProtocolException, ProtocolError, IOException
+        {
+            return mDelegate.queryResult(uri, httpRequest);
         }
     }
 }


### PR DESCRIPTION
… most if not all partners. implements #355

Note: `DefaultApi` became an inner class of `AbstractApiService` because that appeared to be the only reasonable location, considering that everything under framework is considered to be SDK internal and may change at any time. `DefaultApi` needed a place where it's safe from being moved during a refactoring.