### PR TITLE
Resize 'Category' down arrow to fix vertical alignment. #371

### DIFF
--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListHeaderFragment.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/eventlist/EventListHeaderFragment.java
@@ -112,7 +112,7 @@ public final class EventListHeaderFragment extends BaseFragment
                 new TextWithIcon(
                         getContext(),
                         new SharedPrefLastSelectedPlace(getContext()).get().namedPlace().name(),
-                        new ThemeDrawableResource(getActivity(), R.attr.schedjoules_dropdownArrow).get()));
+                        new ThemeDrawableResource(getActivity(), R.attr.schedjoules_dropdownArrow_20sp).get()));
     }
 
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/filter/views/FilterTitleView.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/filter/views/FilterTitleView.java
@@ -56,9 +56,9 @@ public final class FilterTitleView implements SmartView<FilterState>
         Context context = mTitleView.getContext();
 
         Integer iconId = filterState.hasSelection() ?
-                R.drawable.schedjoules_ic_arrow_drop_down_white
+                R.drawable.schedjoules_ic_arrow_drop_down_white_16sp
                 :
-                new ThemeDrawableResource(new ContextActivity(context).get(), R.attr.schedjoules_dropdownArrow).get();
+                new ThemeDrawableResource(new ContextActivity(context).get(), R.attr.schedjoules_dropdownArrow_16sp).get();
         mTitleView.setText(new TextWithIcon(context, context.getString(mTitleText), iconId));
     }
 

--- a/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/ThemeDrawableResource.java
+++ b/eventdiscovery-sdk/src/main/java/com/schedjoules/eventdiscovery/framework/utils/ThemeDrawableResource.java
@@ -21,7 +21,6 @@ import android.app.Activity;
 import android.support.annotation.AttrRes;
 import android.util.TypedValue;
 
-import com.schedjoules.eventdiscovery.R;
 import com.schedjoules.eventdiscovery.framework.utils.factory.AbstractLazy;
 import com.schedjoules.eventdiscovery.framework.utils.factory.Factory;
 
@@ -33,7 +32,7 @@ import com.schedjoules.eventdiscovery.framework.utils.factory.Factory;
  */
 public final class ThemeDrawableResource extends AbstractLazy<Integer>
 {
-    public ThemeDrawableResource(final Activity activity, @AttrRes int attrResId)
+    public ThemeDrawableResource(final Activity activity, @AttrRes final int attrResId)
     {
         super(new Factory<Integer>()
         {
@@ -41,7 +40,7 @@ public final class ThemeDrawableResource extends AbstractLazy<Integer>
             public Integer create()
             {
                 TypedValue typedValue = new TypedValue();
-                activity.getTheme().resolveAttribute(R.attr.schedjoules_dropdownArrow, typedValue, true);
+                activity.getTheme().resolveAttribute(attrResId, typedValue, true);
                 return typedValue.resourceId;
             }
         });

--- a/eventdiscovery-sdk/src/main/res/drawable/schedjoules_ic_arrow_drop_down_dark_16sp.xml
+++ b/eventdiscovery-sdk/src/main/res/drawable/schedjoules_ic_arrow_drop_down_dark_16sp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="16sp"
+        android:height="16sp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+            android:fillColor="@color/schedjoules_text_secondary"
+            android:pathData="M6,6l6,6 6,-6z"/>
+</vector>

--- a/eventdiscovery-sdk/src/main/res/drawable/schedjoules_ic_arrow_drop_down_dark_20sp.xml
+++ b/eventdiscovery-sdk/src/main/res/drawable/schedjoules_ic_arrow_drop_down_dark_20sp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="20sp"
+        android:height="20sp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+            android:fillColor="@color/schedjoules_text_secondary"
+            android:pathData="M6,6l6,6 6,-6z"/>
+</vector>

--- a/eventdiscovery-sdk/src/main/res/drawable/schedjoules_ic_arrow_drop_down_light_16sp.xml
+++ b/eventdiscovery-sdk/src/main/res/drawable/schedjoules_ic_arrow_drop_down_light_16sp.xml
@@ -1,9 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="@dimen/schedjoules_toolbar_title_font_size"
-        android:height="@dimen/schedjoules_toolbar_title_font_size"
+        android:width="16sp"
+        android:height="16sp"
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-            android:fillColor="@color/schedjoules_text_secondary"
+            android:fillColor="@color/schedjoules_dark_text_primary"
             android:pathData="M6,6l6,6 6,-6z"/>
 </vector>

--- a/eventdiscovery-sdk/src/main/res/drawable/schedjoules_ic_arrow_drop_down_light_20sp.xml
+++ b/eventdiscovery-sdk/src/main/res/drawable/schedjoules_ic_arrow_drop_down_light_20sp.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="@dimen/schedjoules_toolbar_title_font_size"
-        android:height="@dimen/schedjoules_toolbar_title_font_size"
+        android:width="20sp"
+        android:height="20sp"
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path

--- a/eventdiscovery-sdk/src/main/res/drawable/schedjoules_ic_arrow_drop_down_white_16sp.xml
+++ b/eventdiscovery-sdk/src/main/res/drawable/schedjoules_ic_arrow_drop_down_white_16sp.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="@dimen/schedjoules_toolbar_title_font_size"
-        android:height="@dimen/schedjoules_toolbar_title_font_size"
+        android:width="16sp"
+        android:height="16sp"
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path

--- a/eventdiscovery-sdk/src/main/res/values/attr.xml
+++ b/eventdiscovery-sdk/src/main/res/values/attr.xml
@@ -10,7 +10,10 @@
     <attr name="schedjoules_cardBackgroundColor" format="color"/>
 
     <!-- A drop down arrow -->
-    <attr name="schedjoules_dropdownArrow" format="reference"/>
+    <attr name="schedjoules_dropdownArrow_20sp"
+            format="reference"/>
+    <attr name="schedjoules_dropdownArrow_16sp"
+            format="reference"/>
 
     <!-- The Google attribution in the location picker -->
     <attr name="schedjoules_googleAttribution" format="reference"/>

--- a/eventdiscovery-sdk/src/main/res/values/dimens.xml
+++ b/eventdiscovery-sdk/src/main/res/values/dimens.xml
@@ -25,5 +25,5 @@
     <dimen name="schedjoules_location_list_item_height">72dp</dimen>
     <dimen name="schedjoules_location_list_item_horizontal_margin">16dp</dimen>
 
-    <dimen name="schedjoules_toolbar_title_font_size">20dp</dimen>
+    <dimen name="schedjoules_toolbar_title_font_size">20sp</dimen>
 </resources>

--- a/eventdiscovery-sdk/src/main/res/values/theme_dark.xml
+++ b/eventdiscovery-sdk/src/main/res/values/theme_dark.xml
@@ -23,7 +23,8 @@
 
         <item name="schedjoules_appBarIconColor">@color/schedjoules_dark_text_primary</item>
         <item name="schedjoules_cardListBackground">@color/schedjoules_background_cards_dark</item>
-        <item name="schedjoules_dropdownArrow">@drawable/schedjoules_ic_arrow_drop_down_light</item>
+        <item name="schedjoules_dropdownArrow_20sp">@drawable/schedjoules_ic_arrow_drop_down_light_20sp</item>
+        <item name="schedjoules_dropdownArrow_16sp">@drawable/schedjoules_ic_arrow_drop_down_light_16sp</item>
         <item name="schedjoules_cardBackgroundColor">@color/schedjoules_background_panel_dark</item>
         <item name="schedjoules_googleAttribution">@drawable/powered_by_google_dark</item>
         <item name="schedjoules_schedJoulesAttribution">@drawable/schedjoules_footer_powered_by_dark</item>

--- a/eventdiscovery-sdk/src/main/res/values/theme_light.xml
+++ b/eventdiscovery-sdk/src/main/res/values/theme_light.xml
@@ -21,7 +21,8 @@
 
         <item name="schedjoules_appBarIconColor">@color/schedjoules_text_secondary</item>
         <item name="schedjoules_cardListBackground">@color/schedjoules_background_cards_light</item>
-        <item name="schedjoules_dropdownArrow">@drawable/schedjoules_ic_arrow_drop_down_dark</item>
+        <item name="schedjoules_dropdownArrow_20sp">@drawable/schedjoules_ic_arrow_drop_down_dark_20sp</item>
+        <item name="schedjoules_dropdownArrow_16sp">@drawable/schedjoules_ic_arrow_drop_down_dark_16sp</item>
         <item name="schedjoules_cardBackgroundColor">@color/schedjoules_white</item>
         <item name="schedjoules_googleAttribution">@drawable/powered_by_google_light</item>
         <item name="schedjoules_schedJoulesAttribution">@drawable/schedjoules_footer_powered_by_light</item>


### PR DESCRIPTION
I've created extra vector drawables of the down arrow with different sizes.
Ideally they could be resized on the fly but this solution was simpler now.
I think I've also tried earlier to tint them programatically and it didn't work for this `ImageSpan`. But I am not 100% sure. So it may be worth creating a ticket to try to use one vector drawable and resize and color it, instead of the current 5 resources. But it's the kind of thing that can take away time to experiment with it, so I would leave it for later.

(Note: Up arrow is also coming probably.)